### PR TITLE
For claude messages with extended thinking, export content instead of thoughts

### DIFF
--- a/claude-chat-exporter.js
+++ b/claude-chat-exporter.js
@@ -7,9 +7,9 @@ function extractConversation() {
     const role = isHuman ? 'Human' : 'Claude';
     markdown += `## ${role}:\n\n`;
     
-    const content = isHuman ? message : message.querySelector('.grid-cols-1');
+    const content = isHuman ? message : message.querySelectorAll('.grid-cols-1');
     if (content) {
-      markdown += processContent(content);
+      markdown += processContent(content?.length == undefined ? content : content[content.length - 1]);
     }
     
     markdown += "\n";
@@ -105,3 +105,4 @@ function downloadMarkdown(content, filename) {
 
 const conversationMarkdown = extractConversation();
 downloadMarkdown(conversationMarkdown, 'claude_conversation.md');
+


### PR DESCRIPTION
When extended thinking is enabled, the current version exports only the 'thoughts' message. This change exports the content returned to the user instead.