### PR TITLE
Fix: Add fallback for 'Edit' button in `findEditButton`

### DIFF
--- a/claude-chat-exporter.js
+++ b/claude-chat-exporter.js
@@ -57,6 +57,7 @@ function setupClaudeExporter() {
     editButton = Array.from(allButtons).find(btn =>
       btn.textContent.trim().toLowerCase() === 'edit'
     );
+    if (!editButton) return allButtons[1];
 
     return editButton;
   }


### PR DESCRIPTION
Added a fallback to allButtons[1] in findEditButton when the button with the text 'Edit' cannot be found. This change ensures compatibility and handles cases where the UI might have changed, causing the specific text lookup to fail.

<img width="576" height="194" alt="스크린샷 2025-10-13 오후 7 00 55" src="https://github.com/user-attachments/assets/5fad2fbd-cc8b-4a5f-a566-ee7693b2fd40" />
<img width="555" height="194" alt="스크린샷 2025-10-13 오후 7 01 06" src="https://github.com/user-attachments/assets/f513b9fe-e51c-4586-a93d-4798f7279d2b" />
