### PR TITLE
Fix broken exports caused by Claude UI changes: adopt unified copy-button approach

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ A JavaScript tool that exports Claude.ai conversations with **perfect markdown f
 
 - **🎯 Perfect Markdown Fidelity** - Uses Claude's copy function for exact output
 - **📊 Complete Element Support** - Tables, math, complex formatting, everything
-- **📁 Smart Filename Generation** - Uses actual conversation title
+- **🕐 Timestamps** - Human message timestamps fetched from Claude's API
+- **📁 Smart Filename Generation** - Uses actual conversation title from API
 - **🔧 Future-Proof** - Automatically supports new Claude markdown features
 - **📈 Real-Time Status** - Visual progress indicator during export
 - **🛡️ Robust Error Handling** - Comprehensive error detection and recovery
@@ -14,15 +15,14 @@ A JavaScript tool that exports Claude.ai conversations with **perfect markdown f
 
 ## How It Works
 
-This script combines two reliable methods:
-
-1. **Human Messages**: Simulates clicking edit buttons to access original message content
-2. **Claude Responses**: Intercepts clipboard when copy buttons are clicked
-3. **Perfect Output**: Uses Claude's exact markdown formatting for all elements
+1. **Fetch Metadata** - Calls Claude's internal API to retrieve the conversation title and per-message timestamps before anything is clicked
+2. **Human Messages** - Identifies human message action bars (those *without* a thumbs-up feedback button) and clicks their copy buttons; captures each clipboard write via an intercepted `navigator.clipboard.writeText`
+3. **Claude Responses** - Identifies Claude response action bars (those *with* a thumbs-up feedback button) and clicks their copy buttons; captures each clipboard write the same way
+4. **Perfect Output** - Combines both sets of captured content into a single markdown file, with timestamps on human message headers when available
 
 ### Why Copy Button Approach?
 
-Instead of manually parsing HTML and converting to markdown (which misses tables and complex elements), this tool uses **Claude's own copy button** to ensure 100% accurate markdown output. Combined with edit button simulation for human messages, you get perfect conversation exports.
+Instead of manually parsing HTML and converting to markdown (which misses tables and complex elements), this tool uses **Claude's own copy button** to ensure 100% accurate markdown output for all message types.
 
 ```
 ❌ Manual HTML Parsing:
@@ -65,19 +65,19 @@ Because this uses Claude's copy function, it automatically handles:
 
 ## File Output
 
-- **Filename**: `{conversation-title}.md` (auto-generated)
+- **Filename**: `{conversation-title}.md` (from API, falls back to DOM)
 - **Format**: Perfect markdown matching Claude's copy output
-- **Content**: Complete conversation with proper spacing
+- **Content**: Complete conversation with proper spacing and timestamps
 - **Encoding**: UTF-8 with standard line endings
 
 ## Example Output
 
-The output is **identical** to what you get when copying Claude messages manually:
+The output is **identical** to what you get when copying Claude messages manually, with timestamps added to human message headers:
 
 ```markdown
 # Conversation with Claude
 
-## Human:
+## Human (Feb 23, 2026, 10:30 AM):
 
 Can you create a comparison table of sorting algorithms?
 
@@ -106,15 +106,15 @@ Here's a comprehensive comparison table of sorting algorithms:
 
 ### Performance Tuning
 
-Adjust delays in the `DELAYS` object:
+Adjust the delay between copy button clicks in the `DELAYS` object:
 
 ```javascript
 const DELAYS = {
-  hover: 50, // Time to wait for hover effects (recommended: 50ms)
-  edit: 150, // Time for edit interface to load (recommended: 150ms)
-  copy: 100, // Time between copy operations (recommended: 100ms)
+  copy: 100, // Delay between copy button clicks in ms (increase if messages are missed)
 };
 ```
+
+Increasing `copy` can help on slower machines or when the page is under load. Decreasing it speeds up export but may cause clipboard writes to be missed.
 
 ### UI Selector Updates
 
@@ -122,14 +122,14 @@ If Claude's interface changes, update the `SELECTORS` object:
 
 ```javascript
 const SELECTORS = {
-  userMessage: '[data-testid="user-message"]',
-  messageGroup: '.group',
   copyButton: 'button[data-testid="action-bar-copy"]',
-  editButton: 'button[aria-label="Edit"]',
-  editTextarea: 'textarea',
-  conversationTitle: '[data-testid="chat-title-button"] .truncate, button[data-testid="chat-title-button"] div.truncate'
+  conversationTitle: '[data-testid="chat-title-button"] .truncate, button[data-testid="chat-title-button"] div.truncate',
+  messageActionsGroup: '[role="group"][aria-label="Message actions"]',
+  feedbackButton: 'button[aria-label="Give positive feedback"]'
 };
 ```
+
+The `feedbackButton` selector is what distinguishes Claude's action bars from human message action bars — it only appears on Claude's responses.
 
 ## Performance Metrics
 
@@ -153,9 +153,10 @@ _Requires clipboard API support (available in all modern browsers)_
 
 The script shows real-time progress:
 
-- `Extracting human messages...` - Processing edit buttons
-- `Copying Claude responses...` - Clicking copy buttons
-- `Human: X | Claude: Y` - Current counts
+- `Fetching conversation data...` - Retrieving title and timestamps from API
+- `Copying human messages...` - Clicking human message copy buttons
+- `Copying Claude responses...` - Clicking Claude response copy buttons
+- `Human: X | Claude: Y` - Live capture counts
 - `✅ Downloaded: filename.md` - Success!
 
 ### Common Issues
@@ -174,24 +175,57 @@ The script shows real-time progress:
 
 ## Technical Architecture
 
-### Smart Clipboard Interception
+### Two-Phase Copy Button Capture
+
+Human and Claude message action bars are structurally identical except that Claude's bars include a thumbs-up feedback button. `getCopyButtons` uses this to filter:
 
 ```javascript
-navigator.clipboard.writeText = function (text) {
-  if (interceptorActive && text && text.length > 0) {
-    capturedResponses.push(text); // Capture Claude's exact output
+function getCopyButtons(claudeOnly) {
+  const actionGroups = document.querySelectorAll(SELECTORS.messageActionsGroup);
+  const buttons = [];
+  actionGroups.forEach(group => {
+    const hasFeedback = !!group.querySelector(SELECTORS.feedbackButton);
+    if (hasFeedback === claudeOnly) {
+      const copyBtn = group.querySelector(SELECTORS.copyButton);
+      if (copyBtn) buttons.push(copyBtn);
+    }
+  });
+  return buttons;
+}
+```
+
+`startExport` then runs two sequential phases, switching `currentCapture` between `humanMessages` and `capturedResponses` so the clipboard interceptor routes each write to the right array:
+
+```javascript
+// Phase 1: Human messages
+currentCapture = humanMessages;
+await triggerCopyButtons(humanButtons);
+await waitForClipboardOperations(humanMessages, humanButtons.length);
+
+// Phase 2: Claude responses
+currentCapture = capturedResponses;
+await triggerCopyButtons(claudeButtons);
+await waitForClipboardOperations(capturedResponses, claudeButtons.length);
+```
+
+### Clipboard Interception
+
+```javascript
+navigator.clipboard.writeText = function(text) {
+  if (interceptorActive && text) {
+    const type = currentCapture === humanMessages ? 'user' : 'claude';
+    currentCapture.push({ type, content: text });
   }
 };
 ```
 
-### Edit Button Simulation
+### Timestamp Matching
+
+Timestamps are fetched from Claude's internal API and stored in a `Map<content → timestamp>`. Matching by content (rather than by index) ensures correctness even when the API returns hidden or system messages alongside visible ones:
 
 ```javascript
-// Hover -> Click Edit -> Extract -> Close
-messageContainer.dispatchEvent(new MouseEvent("mouseenter"));
-editButton.click();
-content = textarea.value; // Original message content
-document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+const ts = timestamps?.get(humanMessages[i].content?.trim());
+const header = ts ? `## Human (${ts}):` : `## Human:`;
 ```
 
 ## Advantages Over Manual Methods
@@ -225,7 +259,7 @@ This project benefits from:
 ## Privacy & Security
 
 - **Local Processing** - Everything runs in your browser
-- **No External Calls** - Only interacts with Claude.ai DOM
+- **Same-Origin API Only** - Fetches metadata from Claude's own backend using your existing session; no third-party services involved
 - **Temporary Interception** - Clipboard restored after export
 - **No Data Storage** - Messages processed and downloaded immediately
 

--- a/claude-chat-exporter.js
+++ b/claude-chat-exporter.js
@@ -123,7 +123,7 @@ function setupClaudeExporter() {
 
   // Intercept clipboard writes and route to the active capture target
   navigator.clipboard.writeText = function(text) {
-    if (interceptorActive && text && text.length > 20) {
+    if (interceptorActive && text) {
       const type = currentCapture === humanMessages ? 'user' : 'claude';
       console.log(`📋 Captured ${type} message ${currentCapture.length + 1}`);
       currentCapture.push({ type, content: text });

--- a/claude-chat-exporter.js
+++ b/claude-chat-exporter.js
@@ -2,22 +2,24 @@ function setupClaudeExporter() {
   const originalWriteText = navigator.clipboard.writeText;
   const capturedResponses = [];
   const humanMessages = [];
+  let conversationData = null;
   let interceptorActive = true;
 
   // DOM Selectors - easily modifiable if Claude's UI changes
   const SELECTORS = {
     userMessage: '[data-testid="user-message"]',
-    messageGroup: '.group',
     copyButton: 'button[data-testid="action-bar-copy"]',
     editButton: 'button[aria-label="Edit"]',
     editTextarea: 'textarea',
-    conversationTitle: '[data-testid="chat-title-button"] .truncate, button[data-testid="chat-title-button"] div.truncate'
+    conversationTitle: '[data-testid="chat-title-button"] .truncate, button[data-testid="chat-title-button"] div.truncate',
+    messageActionsGroup: '[role="group"][aria-label="Message actions"]',
+    feedbackButton: 'button[aria-label="Give positive feedback"]'
   };
 
   const DELAYS = {
-    hover: 50,    // Time to wait for hover effects
-    edit: 150,    // Time for edit interface to load
-    copy: 100     // Time between copy operations
+    hover: 50,
+    edit: 150,
+    copy: 100
   };
 
   function downloadMarkdown(content, filename) {
@@ -35,7 +37,76 @@ function setupClaudeExporter() {
     return new Promise(resolve => setTimeout(resolve, ms));
   }
 
+  // Format ISO timestamp to readable format
+  function formatTimestamp(isoString) {
+    if (!isoString) return null;
+    return new Date(isoString).toLocaleString('en-US', {
+      month: 'short', day: 'numeric', year: 'numeric',
+      hour: 'numeric', minute: '2-digit'
+    });
+  }
+
+  // Fetch conversation data from Claude API to get timestamps
+  async function fetchConversationData() {
+    try {
+      const conversationId = window.location.pathname.split('/').pop();
+      const orgId = document.cookie.match(/lastActiveOrg=([^;]+)/)?.[1];
+
+      if (!conversationId || !orgId) {
+        console.warn('Could not get conversation/org ID');
+        return null;
+      }
+
+      const url = `/api/organizations/${orgId}/chat_conversations/${conversationId}?tree=true&rendering_mode=messages&render_all_tools=true`;
+
+      const response = await fetch(url, {
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' }
+      });
+
+      if (!response.ok) {
+        console.warn(`API error: ${response.status}`);
+        return null;
+      }
+
+      return await response.json();
+    } catch (error) {
+      console.warn('Failed to fetch conversation data:', error);
+      return null;
+    }
+  }
+
+  // Extract human message timestamps from API response
+  function getMessageTimestamps(data) {
+    if (!data?.chat_messages) return { human: [] };
+
+    const timestamps = { human: [] };
+
+    for (const msg of data.chat_messages) {
+      if (msg.sender === 'human') {
+        timestamps.human.push(formatTimestamp(msg.created_at));
+      }
+    }
+
+    return timestamps;
+  }
+
   function getConversationTitle() {
+    // First try to get from API data
+    if (conversationData?.name) {
+      const title = conversationData.name.trim();
+      if (title && title !== 'New conversation') {
+        return title
+          .replace(/[<>:"/\\|?*]/g, '_')
+          .replace(/\s+/g, '_')
+          .replace(/_{2,}/g, '_')
+          .replace(/^_+|_+$/g, '')
+          .toLowerCase()
+          .substring(0, 100);
+      }
+    }
+
+    // Fallback to DOM
     const titleElement = document.querySelector(SELECTORS.conversationTitle);
     const title = titleElement?.textContent?.trim();
 
@@ -43,14 +114,13 @@ function setupClaudeExporter() {
       return 'claude_conversation';
     }
 
-    // Sanitize filename: remove/replace invalid characters
     return title
-      .replace(/[<>:"/\\|?*]/g, '_')  // Replace invalid filename chars
-      .replace(/\s+/g, '_')           // Replace spaces with underscores
-      .replace(/_{2,}/g, '_')         // Replace multiple underscores with single
-      .replace(/^_+|_+$/g, '')        // Trim leading/trailing underscores
+      .replace(/[<>:"/\\|?*]/g, '_')
+      .replace(/\s+/g, '_')
+      .replace(/_{2,}/g, '_')
+      .replace(/^_+|_+$/g, '')
       .toLowerCase()
-      .substring(0, 100);             // Limit length
+      .substring(0, 100);
   }
 
   async function extractMessageContent(messageContainer, messageIndex) {
@@ -59,11 +129,19 @@ function setupClaudeExporter() {
       messageContainer.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
       await delay(DELAYS.hover);
 
-      const messageGroup = messageContainer.closest(SELECTORS.messageGroup);
-      const editButton = messageGroup.querySelector(SELECTORS.editButton);
+      // Find the turn container that holds both user message and message actions
+      let turnContainer = messageContainer.parentElement;
+      let editButton = null;
+
+      // Search up the DOM tree until we find the Edit button in a Message actions group
+      while (turnContainer && !editButton) {
+        editButton = turnContainer.querySelector(SELECTORS.messageActionsGroup + ' ' + SELECTORS.editButton);
+        if (!editButton) {
+          turnContainer = turnContainer.parentElement;
+        }
+      }
 
       if (editButton) {
-        console.log(`📝 Extracting message ${messageIndex + 1} via edit`);
         editButton.click();
         await delay(DELAYS.edit);
 
@@ -86,6 +164,7 @@ function setupClaudeExporter() {
 
     } catch (error) {
       console.error(`Failed to extract message ${messageIndex + 1}:`, error);
+      return null;
     } finally {
       // Clean up hover state
       messageContainer.dispatchEvent(new MouseEvent('mouseleave', { bubbles: true }));
@@ -118,8 +197,7 @@ function setupClaudeExporter() {
       console.log(`📋 Captured Claude response ${capturedResponses.length + 1}`);
       capturedResponses.push({
         type: 'claude',
-        content: text,
-        timestamp: Date.now()
+        content: text
       });
       updateStatus();
     }
@@ -140,41 +218,56 @@ function setupClaudeExporter() {
   }
 
   async function triggerClaudeResponseCopy() {
-    const copyButtons = document.querySelectorAll(SELECTORS.copyButton);
+    // Find copy buttons that belong to Claude's responses only
+    // Claude's message action bars contain feedback buttons, user's don't
+    const actionGroups = document.querySelectorAll(SELECTORS.messageActionsGroup);
+    const claudeCopyButtons = [];
 
-    if (copyButtons.length === 0) {
+    actionGroups.forEach(group => {
+      // If this group has feedback buttons, it's Claude's action bar
+      if (group.querySelector(SELECTORS.feedbackButton)) {
+        const copyBtn = group.querySelector(SELECTORS.copyButton);
+        if (copyBtn) {
+          claudeCopyButtons.push(copyBtn);
+        }
+      }
+    });
+
+    if (claudeCopyButtons.length === 0) {
       throw new Error('No Claude copy buttons found!');
     }
 
-    console.log(`🚀 Clicking ${copyButtons.length} Claude copy buttons...`);
+    console.log(`🚀 Clicking ${claudeCopyButtons.length} Claude copy buttons...`);
 
-    // Click all copy buttons with minimal delays
-    for (let i = 0; i < copyButtons.length; i++) {
-      const button = copyButtons[i];
+    // Click Claude's copy buttons with minimal delays
+    for (let i = 0; i < claudeCopyButtons.length; i++) {
+      const button = claudeCopyButtons[i];
       try {
         if (button.offsetParent !== null) {
           button.scrollIntoView({ behavior: 'instant', block: 'nearest' });
           button.click();
-          console.log(`🖱️ Clicked copy button ${i + 1}/${copyButtons.length}`);
+          console.log(`🖱️ Clicked copy button ${i + 1}/${claudeCopyButtons.length}`);
         }
       } catch (error) {
         console.warn(`Failed to click button ${i + 1}:`, error);
       }
 
       // Only delay between clicks, not after the last one
-      if (i < copyButtons.length - 1) {
+      if (i < claudeCopyButtons.length - 1) {
         await delay(DELAYS.copy);
       }
     }
   }
 
-  function buildMarkdown() {
+  function buildMarkdown(timestamps) {
     let markdown = "# Conversation with Claude\n\n";
     const maxLength = Math.max(humanMessages.length, capturedResponses.length);
 
     for (let i = 0; i < maxLength; i++) {
       if (i < humanMessages.length && humanMessages[i].content) {
-        markdown += `## Human:\n\n${humanMessages[i].content}\n\n---\n\n`;
+        const ts = timestamps?.human?.[i];
+        const header = ts ? `## Human (${ts}):` : `## Human:`;
+        markdown += `${header}\n\n${humanMessages[i].content}\n\n---\n\n`;
       }
       if (i < capturedResponses.length) {
         markdown += `## Claude:\n\n${capturedResponses[i].content}\n\n---\n\n`;
@@ -185,8 +278,8 @@ function setupClaudeExporter() {
   }
 
   async function waitForClipboardOperations(expectedCount) {
-    const maxWaitTime = 2000; // Maximum wait time
-    const checkInterval = 100; // Check every 100ms
+    const maxWaitTime = 2000;
+    const checkInterval = 100;
     let elapsed = 0;
 
     while (elapsed < maxWaitTime) {
@@ -201,19 +294,42 @@ function setupClaudeExporter() {
     console.warn(`⚠️ Timeout: Only captured ${capturedResponses.length}/${expectedCount} responses`);
   }
 
+  function countClaudeCopyButtons() {
+    const actionGroups = document.querySelectorAll(SELECTORS.messageActionsGroup);
+    let count = 0;
+    actionGroups.forEach(group => {
+      if (group.querySelector(SELECTORS.feedbackButton) && group.querySelector(SELECTORS.copyButton)) {
+        count++;
+      }
+    });
+    return count;
+  }
+
   async function startExport() {
     try {
+      // Fetch conversation data from API (for timestamps)
+      statusDiv.textContent = 'Fetching conversation data...';
+      conversationData = await fetchConversationData();
+      const timestamps = getMessageTimestamps(conversationData);
+
+      if (conversationData) {
+        console.log(`📅 Got timestamps for ${timestamps.human.length} human messages`);
+      }
+
+      // Extract human messages via edit button
       statusDiv.textContent = 'Extracting human messages...';
       await extractAllHumanMessages();
 
+      // Copy Claude responses via clipboard interception
       statusDiv.textContent = 'Copying Claude responses...';
+      const expectedClaudeResponses = countClaudeCopyButtons();
       await triggerClaudeResponseCopy();
 
-      // Smart wait - only as long as needed
-      const copyButtons = document.querySelectorAll(SELECTORS.copyButton);
-      await waitForClipboardOperations(copyButtons.length);
+      // Wait for clipboard operations to complete
+      await waitForClipboardOperations(expectedClaudeResponses);
 
-      completeExport();
+      // Build and download markdown
+      completeExport(timestamps);
 
     } catch (error) {
       statusDiv.textContent = `Error: ${error.message}`;
@@ -224,7 +340,7 @@ function setupClaudeExporter() {
     }
   }
 
-  function completeExport() {
+  function completeExport(timestamps) {
     interceptorActive = false;
 
     if (humanMessages.length === 0 && capturedResponses.length === 0) {
@@ -233,7 +349,7 @@ function setupClaudeExporter() {
       return;
     }
 
-    const markdown = buildMarkdown();
+    const markdown = buildMarkdown(timestamps);
     const filename = `${getConversationTitle()}.md`;
     downloadMarkdown(markdown, filename);
 

--- a/claude-chat-exporter.js
+++ b/claude-chat-exporter.js
@@ -3,22 +3,18 @@ function setupClaudeExporter() {
   const capturedResponses = [];
   const humanMessages = [];
   let conversationData = null;
+  let currentCapture = capturedResponses;
   let interceptorActive = true;
 
   // DOM Selectors - easily modifiable if Claude's UI changes
   const SELECTORS = {
-    userMessage: '[data-testid="user-message"]',
     copyButton: 'button[data-testid="action-bar-copy"]',
-    editButton: 'button[aria-label="Edit"]',
-    editTextarea: 'textarea',
     conversationTitle: '[data-testid="chat-title-button"] .truncate, button[data-testid="chat-title-button"] div.truncate',
     messageActionsGroup: '[role="group"][aria-label="Message actions"]',
     feedbackButton: 'button[aria-label="Give positive feedback"]'
   };
 
   const DELAYS = {
-    hover: 50,
-    edit: 150,
     copy: 100
   };
 
@@ -123,82 +119,12 @@ function setupClaudeExporter() {
       .substring(0, 100);
   }
 
-  async function extractMessageContent(messageContainer, messageIndex) {
-    try {
-      // Trigger hover to reveal edit button
-      messageContainer.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
-      await delay(DELAYS.hover);
-
-      // Find the turn container that holds both user message and message actions
-      let turnContainer = messageContainer.parentElement;
-      let editButton = null;
-
-      // Search up the DOM tree until we find the Edit button in a Message actions group
-      while (turnContainer && !editButton) {
-        editButton = turnContainer.querySelector(SELECTORS.messageActionsGroup + ' ' + SELECTORS.editButton);
-        if (!editButton) {
-          turnContainer = turnContainer.parentElement;
-        }
-      }
-
-      if (editButton) {
-        editButton.click();
-        await delay(DELAYS.edit);
-
-        // Get content from edit interface
-        const editTextarea = document.querySelector(SELECTORS.editTextarea);
-
-        let content = '';
-        if (editTextarea) {
-          content = editTextarea.value;
-        }
-
-        // Close edit mode
-        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
-        await delay(DELAYS.hover);
-
-        if (content) return content;
-      }
-
-      throw new Error(`Edit button not found`);
-
-    } catch (error) {
-      console.error(`Failed to extract message ${messageIndex + 1}:`, error);
-      return null;
-    } finally {
-      // Clean up hover state
-      messageContainer.dispatchEvent(new MouseEvent('mouseleave', { bubbles: true }));
-    }
-  }
-
-  async function extractAllHumanMessages() {
-    const userMessages = document.querySelectorAll(SELECTORS.userMessage);
-
-    console.log(`🔄 Extracting ${userMessages.length} human messages...`);
-
-    for (let i = 0; i < userMessages.length; i++) {
-      const content = await extractMessageContent(userMessages[i], i);
-      if (content) {
-        humanMessages.push({
-          type: 'user',
-          content: content,
-          index: i
-        });
-        updateStatus();
-      }
-    }
-
-    console.log(`✅ Extracted ${humanMessages.length} human messages`);
-  }
-
-  // Intercept clipboard writes for Claude responses
+  // Intercept clipboard writes and route to the active capture target
   navigator.clipboard.writeText = function(text) {
     if (interceptorActive && text && text.length > 20) {
-      console.log(`📋 Captured Claude response ${capturedResponses.length + 1}`);
-      capturedResponses.push({
-        type: 'claude',
-        content: text
-      });
+      const type = currentCapture === humanMessages ? 'user' : 'claude';
+      console.log(`📋 Captured ${type} message ${currentCapture.length + 1}`);
+      currentCapture.push({ type, content: text });
       updateStatus();
     }
   };
@@ -217,43 +143,36 @@ function setupClaudeExporter() {
     statusDiv.textContent = `Human: ${humanMessages.length} | Claude: ${capturedResponses.length}`;
   }
 
-  async function triggerClaudeResponseCopy() {
-    // Find copy buttons that belong to Claude's responses only
-    // Claude's message action bars contain feedback buttons, user's don't
+  // Returns copy buttons from action bars filtered by message type.
+  // claudeOnly=true  → action bars WITH a feedback button (Claude responses)
+  // claudeOnly=false → action bars WITHOUT a feedback button (human messages)
+  function getCopyButtons(claudeOnly) {
     const actionGroups = document.querySelectorAll(SELECTORS.messageActionsGroup);
-    const claudeCopyButtons = [];
-
+    const buttons = [];
     actionGroups.forEach(group => {
-      // If this group has feedback buttons, it's Claude's action bar
-      if (group.querySelector(SELECTORS.feedbackButton)) {
+      const hasFeedback = !!group.querySelector(SELECTORS.feedbackButton);
+      if (hasFeedback === claudeOnly) {
         const copyBtn = group.querySelector(SELECTORS.copyButton);
-        if (copyBtn) {
-          claudeCopyButtons.push(copyBtn);
-        }
+        if (copyBtn) buttons.push(copyBtn);
       }
     });
+    return buttons;
+  }
 
-    if (claudeCopyButtons.length === 0) {
-      throw new Error('No Claude copy buttons found!');
-    }
-
-    console.log(`🚀 Clicking ${claudeCopyButtons.length} Claude copy buttons...`);
-
-    // Click Claude's copy buttons with minimal delays
-    for (let i = 0; i < claudeCopyButtons.length; i++) {
-      const button = claudeCopyButtons[i];
+  async function triggerCopyButtons(buttons) {
+    for (let i = 0; i < buttons.length; i++) {
       try {
-        if (button.offsetParent !== null) {
-          button.scrollIntoView({ behavior: 'instant', block: 'nearest' });
-          button.click();
-          console.log(`🖱️ Clicked copy button ${i + 1}/${claudeCopyButtons.length}`);
+        if (buttons[i].offsetParent !== null) {
+          buttons[i].scrollIntoView({ behavior: 'instant', block: 'nearest' });
+          buttons[i].click();
+          console.log(`🖱️ Clicked copy button ${i + 1}/${buttons.length}`);
         }
       } catch (error) {
         console.warn(`Failed to click button ${i + 1}:`, error);
       }
 
       // Only delay between clicks, not after the last one
-      if (i < claudeCopyButtons.length - 1) {
+      if (i < buttons.length - 1) {
         await delay(DELAYS.copy);
       }
     }
@@ -277,13 +196,13 @@ function setupClaudeExporter() {
     return markdown;
   }
 
-  async function waitForClipboardOperations(expectedCount) {
+  async function waitForClipboardOperations(targetArray, expectedCount) {
     const maxWaitTime = 2000;
     const checkInterval = 100;
     let elapsed = 0;
 
     while (elapsed < maxWaitTime) {
-      if (capturedResponses.length >= expectedCount) {
+      if (targetArray.length >= expectedCount) {
         console.log(`✅ All ${expectedCount} responses captured in ${elapsed}ms`);
         return;
       }
@@ -291,23 +210,12 @@ function setupClaudeExporter() {
       elapsed += checkInterval;
     }
 
-    console.warn(`⚠️ Timeout: Only captured ${capturedResponses.length}/${expectedCount} responses`);
-  }
-
-  function countClaudeCopyButtons() {
-    const actionGroups = document.querySelectorAll(SELECTORS.messageActionsGroup);
-    let count = 0;
-    actionGroups.forEach(group => {
-      if (group.querySelector(SELECTORS.feedbackButton) && group.querySelector(SELECTORS.copyButton)) {
-        count++;
-      }
-    });
-    return count;
+    console.warn(`⚠️ Timeout: Only captured ${targetArray.length}/${expectedCount} responses`);
   }
 
   async function startExport() {
     try {
-      // Fetch conversation data from API (for timestamps)
+      // Fetch conversation data from API (for timestamps and title)
       statusDiv.textContent = 'Fetching conversation data...';
       conversationData = await fetchConversationData();
       const timestamps = getMessageTimestamps(conversationData);
@@ -316,19 +224,25 @@ function setupClaudeExporter() {
         console.log(`📅 Got timestamps for ${timestamps.human.length} human messages`);
       }
 
-      // Extract human messages via edit button
-      statusDiv.textContent = 'Extracting human messages...';
-      await extractAllHumanMessages();
+      const humanButtons = getCopyButtons(false);
+      const claudeButtons = getCopyButtons(true);
 
-      // Copy Claude responses via clipboard interception
+      if (humanButtons.length === 0 && claudeButtons.length === 0) {
+        throw new Error('No copy buttons found!');
+      }
+
+      // Phase 1: Human messages
+      statusDiv.textContent = 'Copying human messages...';
+      currentCapture = humanMessages;
+      await triggerCopyButtons(humanButtons);
+      await waitForClipboardOperations(humanMessages, humanButtons.length);
+
+      // Phase 2: Claude responses
       statusDiv.textContent = 'Copying Claude responses...';
-      const expectedClaudeResponses = countClaudeCopyButtons();
-      await triggerClaudeResponseCopy();
+      currentCapture = capturedResponses;
+      await triggerCopyButtons(claudeButtons);
+      await waitForClipboardOperations(capturedResponses, claudeButtons.length);
 
-      // Wait for clipboard operations to complete
-      await waitForClipboardOperations(expectedClaudeResponses);
-
-      // Build and download markdown
       completeExport(timestamps);
 
     } catch (error) {

--- a/claude-chat-exporter.js
+++ b/claude-chat-exporter.js
@@ -72,19 +72,21 @@ function setupClaudeExporter() {
     }
   }
 
-  // Extract human message timestamps from API response
+  // Build a content → timestamp map for human messages from API response.
+  // Matching by content avoids index misalignment caused by hidden/system
+  // messages that the API returns but the UI does not display.
   function getMessageTimestamps(data) {
-    if (!data?.chat_messages) return { human: [] };
-
-    const timestamps = { human: [] };
+    const map = new Map();
+    if (!data?.chat_messages) return map;
 
     for (const msg of data.chat_messages) {
       if (msg.sender === 'human') {
-        timestamps.human.push(formatTimestamp(msg.created_at));
+        const text = msg.content?.map(c => c.text ?? '').join('').trim();
+        if (text) map.set(text, formatTimestamp(msg.created_at));
       }
     }
 
-    return timestamps;
+    return map;
   }
 
   function getConversationTitle() {
@@ -184,7 +186,7 @@ function setupClaudeExporter() {
 
     for (let i = 0; i < maxLength; i++) {
       if (i < humanMessages.length && humanMessages[i].content) {
-        const ts = timestamps?.human?.[i];
+        const ts = timestamps?.get(humanMessages[i].content?.trim());
         const header = ts ? `## Human (${ts}):` : `## Human:`;
         markdown += `${header}\n\n${humanMessages[i].content}\n\n---\n\n`;
       }
@@ -221,7 +223,7 @@ function setupClaudeExporter() {
       const timestamps = getMessageTimestamps(conversationData);
 
       if (conversationData) {
-        console.log(`📅 Got timestamps for ${timestamps.human.length} human messages`);
+        console.log(`📅 Got timestamps for ${timestamps.size} human messages`);
       }
 
       const humanButtons = getCopyButtons(false);


### PR DESCRIPTION
## Summary

Claude's UI changes caused the previous edit-button-based extraction of human
messages to break. This PR replaces that fragile mechanism with a unified
copy-button approach for all message types, restoring reliable export.

**Changes:**
- Replace edit-button simulation (hover → click edit → read textarea → Escape)
  with copy-button interception for both human and Claude messages. Message type
  is determined by the presence of a feedback button — Claude responses have one,
  human messages don't.
- Fetch conversation metadata (title, timestamps) from Claude's internal API
  instead of relying solely on DOM scraping.
- Fix timestamp misalignment: the API returns hidden/system messages alongside
  visible ones, causing index-based timestamp assignment to map to the wrong
  messages. Matching is now done by message content instead.

Closes #8, closes #9, closes #12.

---

Co-authored-by: tassa-yoniso-manasi-karoto
Based on work from #10 by @tassa-yoniso-manasi-karoto