### PR TITLE
Add a manual export button to Claude controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A JavaScript tool that exports Claude.ai conversations with **perfect markdown f
 - **📊 Complete Element Support** - Tables, math, complex formatting, everything
 - **🕐 Timestamps** - Human message timestamps fetched from Claude's API
 - **📁 Smart Filename Generation** - Uses actual conversation title from API
+- **🖱️ Manual Export Button** - Adds an `Export` button to Claude's top-right controls
 - **🔧 Future-Proof** - Automatically supports new Claude markdown features
 - **📈 Real-Time Status** - Visual progress indicator during export
 - **🛡️ Robust Error Handling** - Comprehensive error detection and recovery
@@ -46,8 +47,9 @@ Instead of manually parsing HTML and converting to markdown (which misses tables
    - Firefox: Press F12 or Ctrl+Shift+K (Windows/Linux) or Cmd+Option+K (Mac)
    - Safari: Enable the Develop menu in preferences, then press Cmd+Option+C
 3. Copy the entire script in the file `claude-chat-exporter.js` and paste it into the console.
-4. Press Enter to run the script.
-5. The script will show a progress indicator and will automatically generate and download a file named `{conversation-title}.md` (auto-generated with `conversation-title` being the Claude conversation title).
+4. Press Enter to inject the exporter into the page.
+5. Click the `Export` button that appears in Claude's top-right controls next to `Share`.
+6. The script will show a progress indicator and then download a file named `{conversation-title}.md` (`conversation-title` comes from the Claude conversation title).
 
 ## Complete Element Support
 
@@ -125,11 +127,13 @@ const SELECTORS = {
   copyButton: 'button[data-testid="action-bar-copy"]',
   conversationTitle: '[data-testid="chat-title-button"] .truncate, button[data-testid="chat-title-button"] div.truncate',
   messageActionsGroup: '[role="group"][aria-label="Message actions"]',
-  feedbackButton: 'button[aria-label="Give positive feedback"]'
+  feedbackButton: 'button[aria-label="Give positive feedback"]',
+  controlsContainer: 'div[data-testid="wiggle-controls-actions"]'
 };
 ```
 
 The `feedbackButton` selector is what distinguishes Claude's action bars from human message action bars — it only appears on Claude's responses.
+The `controlsContainer` selector is where the script injects the manual `Export` button.
 
 ## Performance Metrics
 
@@ -153,10 +157,10 @@ _Requires clipboard API support (available in all modern browsers)_
 
 The script shows real-time progress:
 
+- `Export` - Starts the export on demand from Claude's control bar
 - `Fetching conversation data...` - Retrieving title and timestamps from API
 - `Copying human messages...` - Clicking human message copy buttons
 - `Copying Claude responses...` - Clicking Claude response copy buttons
-- `Human: X | Claude: Y` - Live capture counts
 - `✅ Downloaded: filename.md` - Success!
 
 ### Common Issues
@@ -194,18 +198,14 @@ function getCopyButtons(claudeOnly) {
 }
 ```
 
-`startExport` then runs two sequential phases, switching `currentCapture` between `humanMessages` and `capturedResponses` so the clipboard interceptor routes each write to the right array:
+Clicking `Export` runs two sequential phases, one for human messages and one for Claude responses:
 
 ```javascript
-// Phase 1: Human messages
-currentCapture = humanMessages;
-await triggerCopyButtons(humanButtons);
-await waitForClipboardOperations(humanMessages, humanButtons.length);
+showStatus('Copying human messages...');
+await captureButtons(humanButtons, humanMessages);
 
-// Phase 2: Claude responses
-currentCapture = capturedResponses;
-await triggerCopyButtons(claudeButtons);
-await waitForClipboardOperations(capturedResponses, claudeButtons.length);
+showStatus('Copying Claude responses...');
+await captureButtons(claudeButtons, capturedResponses);
 ```
 
 ### Clipboard Interception
@@ -213,9 +213,10 @@ await waitForClipboardOperations(capturedResponses, claudeButtons.length);
 ```javascript
 navigator.clipboard.writeText = function(text) {
   if (interceptorActive && text) {
-    const type = currentCapture === humanMessages ? 'user' : 'claude';
-    currentCapture.push({ type, content: text });
+    targetArray.push({ content: text });
   }
+
+  return originalWriteText(text);
 };
 ```
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ Instead of manually parsing HTML and converting to markdown (which misses tables
 
 ## Usage
 
+There are two ways to use the exporter:
+
+### Option 1: Run from the browser console
+
 1. Open your conversation with Claude in your web browser.
 2. Open the browser's developer console:
    - Chrome/Edge: Press F12 or Ctrl+Shift+J (Windows/Linux) or Cmd+Option+J (Mac)
@@ -50,6 +54,13 @@ Instead of manually parsing HTML and converting to markdown (which misses tables
 4. Press Enter to inject the exporter into the page.
 5. Click the `Export` button that appears in Claude's top-right controls next to `Share`.
 6. The script will show a progress indicator and then download a file named `{conversation-title}.md` (`conversation-title` comes from the Claude conversation title).
+
+### Option 2: Install as a userscript
+
+1. Install a userscript manager such as Tampermonkey, Violentmonkey, or Greasemonkey.
+2. Create a new userscript and paste in the contents of `claude-chat-exporter.user.js`.
+3. Save the userscript and open any Claude conversation.
+4. Click the `Export` button that appears in Claude's top-right controls next to `Share`.
 
 ## Complete Element Support
 

--- a/claude-chat-exporter.js
+++ b/claude-chat-exporter.js
@@ -1,17 +1,15 @@
 function setupClaudeExporter() {
-  const originalWriteText = navigator.clipboard.writeText;
-  const capturedResponses = [];
-  const humanMessages = [];
   let conversationData = null;
-  let currentCapture = capturedResponses;
-  let interceptorActive = true;
+  let statusDiv = null;
+  let exportButton = null;
+  let isExporting = false;
 
-  // DOM Selectors - easily modifiable if Claude's UI changes
   const SELECTORS = {
     copyButton: 'button[data-testid="action-bar-copy"]',
     conversationTitle: '[data-testid="chat-title-button"] .truncate, button[data-testid="chat-title-button"] div.truncate',
     messageActionsGroup: '[role="group"][aria-label="Message actions"]',
-    feedbackButton: 'button[aria-label="Give positive feedback"]'
+    feedbackButton: 'button[aria-label="Give positive feedback"]',
+    controlsContainer: 'div[data-testid="wiggle-controls-actions"]'
   };
 
   const DELAYS = {
@@ -33,7 +31,6 @@ function setupClaudeExporter() {
     return new Promise(resolve => setTimeout(resolve, ms));
   }
 
-  // Format ISO timestamp to readable format
   function formatTimestamp(isoString) {
     if (!isoString) return null;
     return new Date(isoString).toLocaleString('en-US', {
@@ -42,18 +39,17 @@ function setupClaudeExporter() {
     });
   }
 
-  // Fetch conversation data from Claude API to get timestamps
   async function fetchConversationData() {
     try {
-      const conversationId = window.location.pathname.split('/').pop();
-      const orgId = document.cookie.match(/lastActiveOrg=([^;]+)/)?.[1];
+      const conversationId = window.location.pathname.split('/').filter(Boolean).pop();
+      const orgId = document.cookie.match(/(?:^|;\s*)lastActiveOrg=([^;]+)/)?.[1];
 
       if (!conversationId || !orgId) {
         console.warn('Could not get conversation/org ID');
         return null;
       }
 
-      const url = `/api/organizations/${orgId}/chat_conversations/${conversationId}?tree=true&rendering_mode=messages&render_all_tools=true`;
+      const url = `/api/organizations/${decodeURIComponent(orgId)}/chat_conversations/${conversationId}?tree=true&rendering_mode=messages&render_all_tools=true`;
 
       const response = await fetch(url, {
         credentials: 'include',
@@ -72,9 +68,6 @@ function setupClaudeExporter() {
     }
   }
 
-  // Build a content → timestamp map for human messages from API response.
-  // Matching by content avoids index misalignment caused by hidden/system
-  // messages that the API returns but the UI does not display.
   function getMessageTimestamps(data) {
     const map = new Map();
     if (!data?.chat_messages) return map;
@@ -89,29 +82,7 @@ function setupClaudeExporter() {
     return map;
   }
 
-  function getConversationTitle() {
-    // First try to get from API data
-    if (conversationData?.name) {
-      const title = conversationData.name.trim();
-      if (title && title !== 'New conversation') {
-        return title
-          .replace(/[<>:"/\\|?*]/g, '_')
-          .replace(/\s+/g, '_')
-          .replace(/_{2,}/g, '_')
-          .replace(/^_+|_+$/g, '')
-          .toLowerCase()
-          .substring(0, 100);
-      }
-    }
-
-    // Fallback to DOM
-    const titleElement = document.querySelector(SELECTORS.conversationTitle);
-    const title = titleElement?.textContent?.trim();
-
-    if (!title || title === 'Claude' || title.includes('New conversation')) {
-      return 'claude_conversation';
-    }
-
+  function sanitizeFilename(title) {
     return title
       .replace(/[<>:"/\\|?*]/g, '_')
       .replace(/\s+/g, '_')
@@ -121,36 +92,58 @@ function setupClaudeExporter() {
       .substring(0, 100);
   }
 
-  // Intercept clipboard writes and route to the active capture target
-  navigator.clipboard.writeText = function(text) {
-    if (interceptorActive && text) {
-      const type = currentCapture === humanMessages ? 'user' : 'claude';
-      console.log(`📋 Captured ${type} message ${currentCapture.length + 1}`);
-      currentCapture.push({ type, content: text });
-      updateStatus();
+  function getConversationTitle() {
+    if (conversationData?.name) {
+      const title = conversationData.name.trim();
+      if (title && title !== 'New conversation') {
+        return sanitizeFilename(title);
+      }
     }
-  };
 
-  // Create status indicator
-  const statusDiv = document.createElement('div');
-  statusDiv.style.cssText = `
-    position: fixed; top: 10px; right: 10px; z-index: 10000;
-    background: #2196F3; color: white; padding: 10px 15px;
-    border-radius: 5px; font-family: monospace; font-size: 12px;
-    box-shadow: 0 2px 10px rgba(0,0,0,0.3); max-width: 300px;
-  `;
-  document.body.appendChild(statusDiv);
+    const titleElement = document.querySelector(SELECTORS.conversationTitle);
+    const title = titleElement?.textContent?.trim();
 
-  function updateStatus() {
-    statusDiv.textContent = `Human: ${humanMessages.length} | Claude: ${capturedResponses.length}`;
+    if (!title || title === 'Claude' || title.includes('New conversation')) {
+      return 'claude_conversation';
+    }
+
+    return sanitizeFilename(title);
   }
 
-  // Returns copy buttons from action bars filtered by message type.
-  // claudeOnly=true  → action bars WITH a feedback button (Claude responses)
-  // claudeOnly=false → action bars WITHOUT a feedback button (human messages)
+  function ensureStatusDiv() {
+    if (statusDiv && document.body.contains(statusDiv)) return statusDiv;
+
+    statusDiv = document.createElement('div');
+    statusDiv.style.cssText = `
+      position: fixed; top: 10px; right: 10px; z-index: 10000;
+      background: #2196F3; color: white; padding: 10px 15px;
+      border-radius: 5px; font-family: monospace; font-size: 12px;
+      box-shadow: 0 2px 10px rgba(0,0,0,0.3); max-width: 300px;
+    `;
+    document.body.appendChild(statusDiv);
+
+    return statusDiv;
+  }
+
+  function showStatus(message, background = '#2196F3') {
+    const element = ensureStatusDiv();
+    element.textContent = message;
+    element.style.background = background;
+  }
+
+  function cleanupStatus() {
+    setTimeout(() => {
+      if (statusDiv && document.body.contains(statusDiv)) {
+        document.body.removeChild(statusDiv);
+      }
+      statusDiv = null;
+    }, 3000);
+  }
+
   function getCopyButtons(claudeOnly) {
     const actionGroups = document.querySelectorAll(SELECTORS.messageActionsGroup);
     const buttons = [];
+
     actionGroups.forEach(group => {
       const hasFeedback = !!group.querySelector(SELECTORS.feedbackButton);
       if (hasFeedback === claudeOnly) {
@@ -158,29 +151,60 @@ function setupClaudeExporter() {
         if (copyBtn) buttons.push(copyBtn);
       }
     });
+
     return buttons;
   }
 
-  async function triggerCopyButtons(buttons) {
-    for (let i = 0; i < buttons.length; i++) {
-      try {
-        if (buttons[i].offsetParent !== null) {
-          buttons[i].scrollIntoView({ behavior: 'instant', block: 'nearest' });
-          buttons[i].click();
-          console.log(`🖱️ Clicked copy button ${i + 1}/${buttons.length}`);
-        }
-      } catch (error) {
-        console.warn(`Failed to click button ${i + 1}:`, error);
+  async function captureButtons(buttons, targetArray) {
+    const originalWriteText = navigator.clipboard.writeText.bind(navigator.clipboard);
+    let interceptorActive = true;
+
+    navigator.clipboard.writeText = function(text) {
+      if (interceptorActive && text) {
+        targetArray.push({ content: text });
       }
 
-      // Only delay between clicks, not after the last one
-      if (i < buttons.length - 1) {
-        await delay(DELAYS.copy);
+      return originalWriteText(text);
+    };
+
+    try {
+      for (let i = 0; i < buttons.length; i++) {
+        try {
+          if (buttons[i].offsetParent !== null) {
+            buttons[i].scrollIntoView({ behavior: 'instant', block: 'nearest' });
+            buttons[i].click();
+            console.log(`Clicked copy button ${i + 1}/${buttons.length}`);
+          }
+        } catch (error) {
+          console.warn(`Failed to click button ${i + 1}:`, error);
+        }
+
+        if (i < buttons.length - 1) {
+          await delay(DELAYS.copy);
+        }
       }
+
+      const maxWaitTime = 2000;
+      const checkInterval = 100;
+      let elapsed = 0;
+
+      while (elapsed < maxWaitTime) {
+        if (targetArray.length >= buttons.length) {
+          return;
+        }
+
+        await delay(checkInterval);
+        elapsed += checkInterval;
+      }
+
+      console.warn(`Timeout: Only captured ${targetArray.length}/${buttons.length} responses`);
+    } finally {
+      interceptorActive = false;
+      navigator.clipboard.writeText = originalWriteText;
     }
   }
 
-  function buildMarkdown(timestamps) {
+  function buildMarkdown(humanMessages, capturedResponses, timestamps) {
     let markdown = "# Conversation with Claude\n\n";
     const maxLength = Math.max(humanMessages.length, capturedResponses.length);
 
@@ -190,7 +214,7 @@ function setupClaudeExporter() {
         const header = ts ? `## Human (${ts}):` : `## Human:`;
         markdown += `${header}\n\n${humanMessages[i].content}\n\n---\n\n`;
       }
-      if (i < capturedResponses.length) {
+      if (i < capturedResponses.length && capturedResponses[i].content) {
         markdown += `## Claude:\n\n${capturedResponses[i].content}\n\n---\n\n`;
       }
     }
@@ -198,33 +222,26 @@ function setupClaudeExporter() {
     return markdown;
   }
 
-  async function waitForClipboardOperations(targetArray, expectedCount) {
-    const maxWaitTime = 2000;
-    const checkInterval = 100;
-    let elapsed = 0;
+  function setButtonState() {
+    if (!exportButton) return;
 
-    while (elapsed < maxWaitTime) {
-      if (targetArray.length >= expectedCount) {
-        console.log(`✅ All ${expectedCount} responses captured in ${elapsed}ms`);
-        return;
-      }
-      await delay(checkInterval);
-      elapsed += checkInterval;
-    }
-
-    console.warn(`⚠️ Timeout: Only captured ${targetArray.length}/${expectedCount} responses`);
+    exportButton.disabled = isExporting;
+    exportButton.textContent = isExporting ? 'Exporting...' : 'Export';
   }
 
   async function startExport() {
+    if (isExporting) return;
+
+    isExporting = true;
+    setButtonState();
+
     try {
-      // Fetch conversation data from API (for timestamps and title)
-      statusDiv.textContent = 'Fetching conversation data...';
+      const humanMessages = [];
+      const capturedResponses = [];
+
+      showStatus('Fetching conversation data...');
       conversationData = await fetchConversationData();
       const timestamps = getMessageTimestamps(conversationData);
-
-      if (conversationData) {
-        console.log(`📅 Got timestamps for ${timestamps.size} human messages`);
-      }
 
       const humanButtons = getCopyButtons(false);
       const claudeButtons = getCopyButtons(true);
@@ -233,59 +250,84 @@ function setupClaudeExporter() {
         throw new Error('No copy buttons found!');
       }
 
-      // Phase 1: Human messages
-      statusDiv.textContent = 'Copying human messages...';
-      currentCapture = humanMessages;
-      await triggerCopyButtons(humanButtons);
-      await waitForClipboardOperations(humanMessages, humanButtons.length);
+      showStatus('Copying human messages...');
+      await captureButtons(humanButtons, humanMessages);
 
-      // Phase 2: Claude responses
-      statusDiv.textContent = 'Copying Claude responses...';
-      currentCapture = capturedResponses;
-      await triggerCopyButtons(claudeButtons);
-      await waitForClipboardOperations(capturedResponses, claudeButtons.length);
+      showStatus('Copying Claude responses...');
+      await captureButtons(claudeButtons, capturedResponses);
 
-      completeExport(timestamps);
+      if (humanMessages.length === 0 && capturedResponses.length === 0) {
+        throw new Error('No messages captured!');
+      }
 
+      const markdown = buildMarkdown(humanMessages, capturedResponses, timestamps);
+      const filename = `${getConversationTitle()}.md`;
+      downloadMarkdown(markdown, filename);
+
+      showStatus(`Downloaded: ${filename}`, '#4CAF50');
     } catch (error) {
-      statusDiv.textContent = `Error: ${error.message}`;
-      statusDiv.style.background = '#f44336';
+      showStatus(`Error: ${error.message}`, '#f44336');
       console.error('Export failed:', error);
     } finally {
-      setTimeout(cleanup, 3000);
+      isExporting = false;
+      setButtonState();
+      cleanupStatus();
     }
   }
 
-  function completeExport(timestamps) {
-    interceptorActive = false;
+  function createExportButton() {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.dataset.claudeExporterButton = 'true';
+    button.className = `inline-flex
+  items-center
+  justify-center
+  relative
+  isolate
+  shrink-0
+  can-focus
+  select-none
+  disabled:pointer-events-none
+  disabled:opacity-50
+  disabled:shadow-none
+  disabled:drop-shadow-none font-base-bold
+          border-0.5
+          overflow-hidden
+          transition
+          duration-100
+          backface-hidden h-8 rounded-md px-3 min-w-[4rem] whitespace-nowrap !text-xs _fill_1abo4_9 _secondary_1abo4_72`;
+    button.textContent = 'Export';
+    button.addEventListener('click', startExport);
 
-    if (humanMessages.length === 0 && capturedResponses.length === 0) {
-      statusDiv.textContent = 'No messages captured!';
-      statusDiv.style.background = '#f44336';
+    return button;
+  }
+
+  function insertExportButton() {
+    const container = document.querySelector(SELECTORS.controlsContainer);
+    if (!container) return;
+
+    const existingButton = container.querySelector('[data-claude-exporter-button="true"]');
+    if (existingButton) {
+      exportButton = existingButton;
+      setButtonState();
       return;
     }
 
-    const markdown = buildMarkdown(timestamps);
-    const filename = `${getConversationTitle()}.md`;
-    downloadMarkdown(markdown, filename);
-
-    statusDiv.textContent = `✅ Downloaded: ${filename}`;
-    statusDiv.style.background = '#4CAF50';
-
-    console.log('🎉 Export complete!');
+    exportButton = createExportButton();
+    container.appendChild(exportButton);
+    setButtonState();
   }
 
-  function cleanup() {
-    navigator.clipboard.writeText = originalWriteText;
-    if (document.body.contains(statusDiv)) {
-      document.body.removeChild(statusDiv);
-    }
-  }
+  insertExportButton();
 
-  // Initialize
-  updateStatus();
-  setTimeout(startExport, 1000);
+  const observer = new MutationObserver(() => {
+    insertExportButton();
+  });
+
+  observer.observe(document.body, {
+    childList: true,
+    subtree: true
+  });
 }
 
-// Run the exporter
 setupClaudeExporter();

--- a/claude-chat-exporter.user.js
+++ b/claude-chat-exporter.user.js
@@ -1,0 +1,351 @@
+// ==UserScript==
+// @name         Claude Chat Exporter
+// @namespace    https://claude.ai/
+// @version      1.0.0
+// @description  Export Claude.ai conversations to Markdown with a manual Export button
+// @match        https://claude.ai/*
+// @match        https://www.claude.ai/*
+// @run-at       document-idle
+// @grant        none
+// ==/UserScript==
+
+(function() {
+  'use strict';
+
+  if (window.__claudeChatExporterLoaded) return;
+  window.__claudeChatExporterLoaded = true;
+
+  function setupClaudeExporter() {
+    let conversationData = null;
+    let statusDiv = null;
+    let exportButton = null;
+    let isExporting = false;
+
+    const SELECTORS = {
+      copyButton: 'button[data-testid="action-bar-copy"]',
+      conversationTitle: '[data-testid="chat-title-button"] .truncate, button[data-testid="chat-title-button"] div.truncate',
+      messageActionsGroup: '[role="group"][aria-label="Message actions"]',
+      feedbackButton: 'button[aria-label="Give positive feedback"]',
+      controlsContainer: 'div[data-testid="wiggle-controls-actions"]'
+    };
+
+    const DELAYS = {
+      copy: 100
+    };
+
+    function downloadMarkdown(content, filename) {
+      const blob = new Blob([content], { type: 'text/markdown' });
+      const a = document.createElement('a');
+      a.href = URL.createObjectURL(blob);
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(a.href);
+    }
+
+    function delay(ms) {
+      return new Promise(resolve => setTimeout(resolve, ms));
+    }
+
+    function formatTimestamp(isoString) {
+      if (!isoString) return null;
+      return new Date(isoString).toLocaleString('en-US', {
+        month: 'short', day: 'numeric', year: 'numeric',
+        hour: 'numeric', minute: '2-digit'
+      });
+    }
+
+    async function fetchConversationData() {
+      try {
+        const conversationId = window.location.pathname.split('/').filter(Boolean).pop();
+        const orgId = document.cookie.match(/(?:^|;\s*)lastActiveOrg=([^;]+)/)?.[1];
+
+        if (!conversationId || !orgId) {
+          console.warn('Could not get conversation/org ID');
+          return null;
+        }
+
+        const url = `/api/organizations/${decodeURIComponent(orgId)}/chat_conversations/${conversationId}?tree=true&rendering_mode=messages&render_all_tools=true`;
+
+        const response = await fetch(url, {
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' }
+        });
+
+        if (!response.ok) {
+          console.warn(`API error: ${response.status}`);
+          return null;
+        }
+
+        return await response.json();
+      } catch (error) {
+        console.warn('Failed to fetch conversation data:', error);
+        return null;
+      }
+    }
+
+    function getMessageTimestamps(data) {
+      const map = new Map();
+      if (!data?.chat_messages) return map;
+
+      for (const msg of data.chat_messages) {
+        if (msg.sender === 'human') {
+          const text = msg.content?.map(c => c.text ?? '').join('').trim();
+          if (text) map.set(text, formatTimestamp(msg.created_at));
+        }
+      }
+
+      return map;
+    }
+
+    function sanitizeFilename(title) {
+      return title
+        .replace(/[<>:"/\\|?*]/g, '_')
+        .replace(/\s+/g, '_')
+        .replace(/_{2,}/g, '_')
+        .replace(/^_+|_+$/g, '')
+        .toLowerCase()
+        .substring(0, 100);
+    }
+
+    function getConversationTitle() {
+      if (conversationData?.name) {
+        const title = conversationData.name.trim();
+        if (title && title !== 'New conversation') {
+          return sanitizeFilename(title);
+        }
+      }
+
+      const titleElement = document.querySelector(SELECTORS.conversationTitle);
+      const title = titleElement?.textContent?.trim();
+
+      if (!title || title === 'Claude' || title.includes('New conversation')) {
+        return 'claude_conversation';
+      }
+
+      return sanitizeFilename(title);
+    }
+
+    function ensureStatusDiv() {
+      if (statusDiv && document.body.contains(statusDiv)) return statusDiv;
+
+      statusDiv = document.createElement('div');
+      statusDiv.style.cssText = `
+        position: fixed; top: 10px; right: 10px; z-index: 10000;
+        background: #2196F3; color: white; padding: 10px 15px;
+        border-radius: 5px; font-family: monospace; font-size: 12px;
+        box-shadow: 0 2px 10px rgba(0,0,0,0.3); max-width: 300px;
+      `;
+      document.body.appendChild(statusDiv);
+
+      return statusDiv;
+    }
+
+    function showStatus(message, background = '#2196F3') {
+      const element = ensureStatusDiv();
+      element.textContent = message;
+      element.style.background = background;
+    }
+
+    function cleanupStatus() {
+      setTimeout(() => {
+        if (statusDiv && document.body.contains(statusDiv)) {
+          document.body.removeChild(statusDiv);
+        }
+        statusDiv = null;
+      }, 3000);
+    }
+
+    function getCopyButtons(claudeOnly) {
+      const actionGroups = document.querySelectorAll(SELECTORS.messageActionsGroup);
+      const buttons = [];
+
+      actionGroups.forEach(group => {
+        const hasFeedback = !!group.querySelector(SELECTORS.feedbackButton);
+        if (hasFeedback === claudeOnly) {
+          const copyBtn = group.querySelector(SELECTORS.copyButton);
+          if (copyBtn) buttons.push(copyBtn);
+        }
+      });
+
+      return buttons;
+    }
+
+    async function captureButtons(buttons, targetArray) {
+      const originalWriteText = navigator.clipboard.writeText.bind(navigator.clipboard);
+      let interceptorActive = true;
+
+      navigator.clipboard.writeText = function(text) {
+        if (interceptorActive && text) {
+          targetArray.push({ content: text });
+        }
+
+        return originalWriteText(text);
+      };
+
+      try {
+        for (let i = 0; i < buttons.length; i++) {
+          try {
+            if (buttons[i].offsetParent !== null) {
+              buttons[i].scrollIntoView({ behavior: 'instant', block: 'nearest' });
+              buttons[i].click();
+              console.log(`Clicked copy button ${i + 1}/${buttons.length}`);
+            }
+          } catch (error) {
+            console.warn(`Failed to click button ${i + 1}:`, error);
+          }
+
+          if (i < buttons.length - 1) {
+            await delay(DELAYS.copy);
+          }
+        }
+
+        const maxWaitTime = 2000;
+        const checkInterval = 100;
+        let elapsed = 0;
+
+        while (elapsed < maxWaitTime) {
+          if (targetArray.length >= buttons.length) {
+            return;
+          }
+
+          await delay(checkInterval);
+          elapsed += checkInterval;
+        }
+
+        console.warn(`Timeout: Only captured ${targetArray.length}/${buttons.length} responses`);
+      } finally {
+        interceptorActive = false;
+        navigator.clipboard.writeText = originalWriteText;
+      }
+    }
+
+    function buildMarkdown(humanMessages, capturedResponses, timestamps) {
+      let markdown = "# Conversation with Claude\n\n";
+      const maxLength = Math.max(humanMessages.length, capturedResponses.length);
+
+      for (let i = 0; i < maxLength; i++) {
+        if (i < humanMessages.length && humanMessages[i].content) {
+          const ts = timestamps?.get(humanMessages[i].content?.trim());
+          const header = ts ? `## Human (${ts}):` : `## Human:`;
+          markdown += `${header}\n\n${humanMessages[i].content}\n\n---\n\n`;
+        }
+        if (i < capturedResponses.length && capturedResponses[i].content) {
+          markdown += `## Claude:\n\n${capturedResponses[i].content}\n\n---\n\n`;
+        }
+      }
+
+      return markdown;
+    }
+
+    function setButtonState() {
+      if (!exportButton) return;
+
+      exportButton.disabled = isExporting;
+      exportButton.textContent = isExporting ? 'Exporting...' : 'Export';
+    }
+
+    async function startExport() {
+      if (isExporting) return;
+
+      isExporting = true;
+      setButtonState();
+
+      try {
+        const humanMessages = [];
+        const capturedResponses = [];
+
+        showStatus('Fetching conversation data...');
+        conversationData = await fetchConversationData();
+        const timestamps = getMessageTimestamps(conversationData);
+
+        const humanButtons = getCopyButtons(false);
+        const claudeButtons = getCopyButtons(true);
+
+        if (humanButtons.length === 0 && claudeButtons.length === 0) {
+          throw new Error('No copy buttons found!');
+        }
+
+        showStatus('Copying human messages...');
+        await captureButtons(humanButtons, humanMessages);
+
+        showStatus('Copying Claude responses...');
+        await captureButtons(claudeButtons, capturedResponses);
+
+        if (humanMessages.length === 0 && capturedResponses.length === 0) {
+          throw new Error('No messages captured!');
+        }
+
+        const markdown = buildMarkdown(humanMessages, capturedResponses, timestamps);
+        const filename = `${getConversationTitle()}.md`;
+        downloadMarkdown(markdown, filename);
+
+        showStatus(`Downloaded: ${filename}`, '#4CAF50');
+      } catch (error) {
+        showStatus(`Error: ${error.message}`, '#f44336');
+        console.error('Export failed:', error);
+      } finally {
+        isExporting = false;
+        setButtonState();
+        cleanupStatus();
+      }
+    }
+
+    function createExportButton() {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.dataset.claudeExporterButton = 'true';
+      button.className = `inline-flex
+    items-center
+    justify-center
+    relative
+    isolate
+    shrink-0
+    can-focus
+    select-none
+    disabled:pointer-events-none
+    disabled:opacity-50
+    disabled:shadow-none
+    disabled:drop-shadow-none font-base-bold
+            border-0.5
+            overflow-hidden
+            transition
+            duration-100
+            backface-hidden h-8 rounded-md px-3 min-w-[4rem] whitespace-nowrap !text-xs _fill_1abo4_9 _secondary_1abo4_72`;
+      button.textContent = 'Export';
+      button.addEventListener('click', startExport);
+
+      return button;
+    }
+
+    function insertExportButton() {
+      const container = document.querySelector(SELECTORS.controlsContainer);
+      if (!container) return;
+
+      const existingButton = container.querySelector('[data-claude-exporter-button="true"]');
+      if (existingButton) {
+        exportButton = existingButton;
+        setButtonState();
+        return;
+      }
+
+      exportButton = createExportButton();
+      container.appendChild(exportButton);
+      setButtonState();
+    }
+
+    insertExportButton();
+
+    const observer = new MutationObserver(() => {
+      insertExportButton();
+    });
+
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true
+    });
+  }
+
+  setupClaudeExporter();
+})();


### PR DESCRIPTION
## Summary
- replace the automatic export-on-load flow with a manual `Export` button in Claude's top-right controls
- add a dedicated `claude-chat-exporter.user.js` userscript file for Tampermonkey/Violentmonkey/Greasemonkey installs
- update the README with the manual export flow and userscript installation steps

## Validation
- node --check claude-chat-exporter.js
- node --check claude-chat-exporter.user.js
