### PR TITLE
Fix exports broken by Claude UI changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,8 @@ If Claude's interface changes, update the `SELECTORS` object:
 ```javascript
 const SELECTORS = {
   copyButton: 'button[data-testid="action-bar-copy"]',
-  conversationTitle: '[data-testid="chat-title-button"] .truncate, button[data-testid="chat-title-button"] div.truncate',
-  messageActionsGroup: '[role="group"][aria-label="Message actions"]',
+  conversationTitle: '[data-testid="chat-title-button"] .truncate, button[data-testid="chat-title-button"] div.truncate, [data-testid="chat-title-split"] .truncate, [data-testid="chat-title-split"] button span.truncate',
+  messageActionsGroup: '[aria-label="Message actions"]',
   feedbackButton: 'button[aria-label="Give positive feedback"]'
 };
 ```

--- a/claude-chat-exporter.js
+++ b/claude-chat-exporter.js
@@ -9,8 +9,8 @@ function setupClaudeExporter() {
   // DOM Selectors - easily modifiable if Claude's UI changes
   const SELECTORS = {
     copyButton: 'button[data-testid="action-bar-copy"]',
-    conversationTitle: '[data-testid="chat-title-button"] .truncate, button[data-testid="chat-title-button"] div.truncate',
-    messageActionsGroup: '[role="group"][aria-label="Message actions"]',
+    conversationTitle: '[data-testid="chat-title-button"] .truncate, button[data-testid="chat-title-button"] div.truncate, [data-testid="chat-title-split"] .truncate, [data-testid="chat-title-split"] button span.truncate',
+    messageActionsGroup: '[aria-label="Message actions"]',
     feedbackButton: 'button[aria-label="Give positive feedback"]'
   };
 
@@ -231,6 +231,12 @@ function setupClaudeExporter() {
 
       if (humanButtons.length === 0 && claudeButtons.length === 0) {
         throw new Error('No copy buttons found!');
+      }
+
+      // A conversation normally has both message types; a one-sided result
+      // suggests the attribution markers changed and export may mislabel
+      if ((humanButtons.length === 0) !== (claudeButtons.length === 0)) {
+        console.warn(`⚠️ Suspicious: ${humanButtons.length} human vs ${claudeButtons.length} Claude copy buttons — attribution markers may have changed`);
       }
 
       // Phase 1: Human messages


### PR DESCRIPTION
## Problem

Claude.ai updated its interface:
- The message action bar container changed from `role="group"` to
  `role="toolbar"` (reported in #24, identified in #26)
- The `chat-title-button` header element was replaced with `chat-title-split`

The stale wrapper selector matched nothing, so every export aborted with
**"No copy buttons found!"** — and the same root cause broke message
attribution (#22).

## Changes

- Match the message action bar on `aria-label` alone, dropping the role
  qualifier so both the old (`group`) and new (`toolbar`) UI variants work
- Add the `chat-title-split` fallback for conversation titles (adopted from
  #27 by @Red007Master), keeping the old `chat-title-button` selector for
  accounts on the previous UI
- Warn when only one message type yields copy buttons, so a future
  attribution-marker change surfaces as a visible signal instead of
  silently mislabeling messages
- Update the README selector reference to match

## Related PRs

Supersedes #25 and #27, which addressed the same breakage — see the
closing comments on each for the rationale. The title selector from #27
is adopted here with credit.

## Verification

- Selectors verified against a sample HTML extract of the current UI:
  the action bar selector matches exactly the two real toolbars, message
  classification yields correct human/Claude attribution, and the title
  fallback resolves from the new header structure
- Old-UI compatibility confirmed: the `role="group"` variant still matches

Fixes #22
Fixes #24
Fixes #26
Closes #25
Closes #27