### PR TITLE
Update feedback button selector to accommodate for Claude UI change

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ const SELECTORS = {
   copyButton: 'button[data-testid="action-bar-copy"]',
   conversationTitle: '[data-testid="chat-title-button"] .truncate, button[data-testid="chat-title-button"] div.truncate, [data-testid="chat-title-split"] .truncate, [data-testid="chat-title-split"] button span.truncate',
   messageActionsGroup: '[aria-label="Message actions"]',
-  feedbackButton: 'button[aria-label="Give positive feedback"]'
+  feedbackButton: 'button[aria-label="Give positive feedback"], button[aria-label="Good response"]'
 };
 ```
 

--- a/claude-chat-exporter.js
+++ b/claude-chat-exporter.js
@@ -11,7 +11,7 @@ function setupClaudeExporter() {
     copyButton: 'button[data-testid="action-bar-copy"]',
     conversationTitle: '[data-testid="chat-title-button"] .truncate, button[data-testid="chat-title-button"] div.truncate, [data-testid="chat-title-split"] .truncate, [data-testid="chat-title-split"] button span.truncate',
     messageActionsGroup: '[aria-label="Message actions"]',
-    feedbackButton: 'button[aria-label="Give positive feedback"]'
+    feedbackButton: 'button[aria-label="Give positive feedback"], button[aria-label="Good response"]'
   };
 
   const DELAYS = {


### PR DESCRIPTION
The `feedbackButton` selector has changed from `Give positive feedback` to `Good response` in the new Claude UI update.

The `feedbackButton` selector has therefore been modified to accommodate for the change while maintaining backward compatibility to work with both variants as given below:
```
feedbackButton: 'button[aria-label="Give positive feedback"], button[aria-label="Good response"]'
```