### PR TITLE
feat!: read conversations from Claude's internal API instead of the DOM

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,82 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+A single-file browser-console script (`claude-chat-exporter.js`) that exports a claude.ai conversation to a markdown file. It runs by pasting the whole file into the browser devtools console while a conversation is open (a one-click bookmarklet in `docs/index.html` wraps the same script). There is **no build system, package manager, test suite, or lint config** — the repo is the script, its README, the bookmarklet page, and a LICENSE.
+
+To test a change: `node --check claude-chat-exporter.js` for syntax, then paste the edited script into the console on a real claude.ai conversation and observe the on-page status indicator and downloaded `.md` file.
+
+## Core design decision
+
+The script does **not** scrape or parse the DOM, and does **not** convert HTML to markdown. It reads the conversation directly from claude.ai's own **internal API**, whose response already contains each message's **source markdown** (tables, math, code, etc.) — so fidelity is byte-perfect with zero conversion logic. Any proposed change that reintroduces DOM scraping, clipboard/copy-button capture, or HTML→markdown parsing works against the entire point of the project — reject that direction.
+
+(Historical note: earlier versions clicked Claude's "copy" buttons and intercepted the clipboard. That was replaced because it only saw the DOM's *virtualized* window — long conversations exported partially and out of order — and coupled the script to constantly-changing CSS selectors. The API returns the same markdown, complete and ordered, and is far more stable. See git history.)
+
+## How the export works
+
+The whole flow lives in `setupClaudeExporter()` (one closure, invoked at the bottom) and is a straight pipeline — one fetch, transform, download:
+
+1. **`fetchConversationData()`** — same-origin GET to the internal endpoint
+   `/api/organizations/{orgId}/chat_conversations/{conversationId}?tree=true&rendering_mode=messages&render_all_tools=true`,
+   authenticated by the user's existing session cookie. `conversationId` comes from the URL path; `orgId` from the `lastActiveOrg` cookie.
+
+2. **`getOrderedMessages(data)`** — turns the response into an ordered `[{ sender, text, created_at, truncated, stop_reason }]`:
+   - **Ordering** follows the *current branch*: walk from `data.current_leaf_message_uuid` up the `parent_message_uuid` chain and reverse (so a regenerated response exports the path actually on screen). Falls back to sorting `chat_messages` by `index`.
+   - **Content**: each message's `content` is an array of typed blocks (`text`, `thinking`, `tool_use`, `tool_result`). Walk them **in order** — emit `text` blocks and `tool_use` blocks (via `renderToolUse`), skip `thinking`/`tool_result` — so text and special elements stay interleaved. Messages that end up empty are dropped (the API also returns hidden/system messages the UI never shows). `renderToolUse` renders only the three content-bearing tools (`artifacts`→`content`, `create_file`→`file_text`, `visualize:show_widget`→`widget_code`) as titled fenced code blocks with an API-derived kind label (`Artifact:` / `File:` / `Widget:`, no emoji); **every other tool** (web search, bash, file view/edit, display widgets, unknown) is skipped (their names are logged once at `console.debug` — hidden from users, but a maintainer can enable "Verbose" to spot a new content tool to add). Artifacts are special — `collectArtifacts` folds each `id` through `create` / `update` (an `old_str`→`new_str` diff) / `rewrite` into its final content, and it's rendered **once, at its last edit** (matched by `version_uuid`).
+
+3. **`buildMarkdown(messages)`** — emits YAML frontmatter (`title`, `source`, `model`, `exported`) then one `# Human — <timestamp>` / `# Claude — <timestamp>` header per turn (H1 so Claude's own `##`/`###` content nests beneath it — keeps the outline correct for RAG chunking and Obsidian). No separate title heading or `---` rules. Appends an inline word-based notice to **incomplete** messages via `incompleteNote()`, flagging the two signals verified in the API — `truncated` → **Truncated**, `stop_reason: 'user_canceled'` → **Interrupted** (everything else, incl. a rare length-limited response, is left unannotated rather than guessing an unverified `stop_reason` value). The exported document is **emoji-free**; emojis appear only in the transient status box / console. Tuned for RAG/Obsidian ingestion.
+
+4. **Title + download** — `getConversationTitle()` uses `conversationData.name` (falls back to `'claude_conversation'`; fully DOM-free), then `downloadMarkdown()` writes the `.md` file.
+
+## The API response contract (the thing to know for maintenance)
+
+```
+{
+  name,                          // conversation title
+  model,                         // e.g. "claude-opus-5" — used in the frontmatter
+  current_leaf_message_uuid,     // tip of the current branch (drives ordering)
+  chat_messages: [{
+    uuid, parent_message_uuid,   // tree links (used to reconstruct the current path)
+    index,                       // fallback ordering
+    sender: 'human' | 'assistant',
+    created_at,                  // ISO timestamp
+    truncated,                   // bool; rare source-data content truncation → inline "Truncated" note
+    stop_reason,                 // assistant only: 'end_turn'/'stop_sequence' = complete, 'user_canceled' = interrupted (flagged); other values left unannotated
+    content: [{ type: 'text' | 'thinking' | 'tool_use' | 'tool_result', text?, ... }],
+    files:       [ /* uploaded files, see below */ ],
+    attachments: [ /* text-extracted docs, see below */ ]
+  }, ...]
+}
+```
+
+**Content blocks** (`content[]`): we export `type === 'text'` (`block.text`) and content-bearing
+`tool_use` blocks; `thinking` / `tool_result` are skipped. A `tool_use` block has `name` +
+`input`; the three the renderer keys on:
+- `artifacts` → `input.{ command: 'create'|'update'|'rewrite', id, title, type, language,
+  content, old_str, new_str, version_uuid }`. `create`/`rewrite` carry full `content`;
+  `update` is an `old_str`→`new_str` diff. `collectArtifacts` folds them by `id` into the
+  final version; `version_uuid` marks the last edit (where it renders).
+- `create_file` → `input.{ path, file_text, description }`.
+- `visualize:show_widget` → `input.{ title, widget_code }` (each is one-shot; no id).
+
+**`files[]`** (uploaded files): `{ file_kind: 'image'|'document'|'blob', file_name, uuid,
+image → preview_url, document → document_asset.url + page_count, blob → size_bytes (no URL) }`.
+**`attachments[]`** (text extractions, e.g. .md/.docx): `{ file_name, file_type, file_size,
+extracted_content }` — no URL; the text itself is inlined.
+
+Note the convenience top-level `chat_messages[].text` field is **empty** in this rendering
+mode — always read the `content` blocks. `startExport` validates that `chat_messages` is an
+array (a clear error if the shape drifts), and non-fatal shape issues (unexpected `sender`,
+un-appliable artifact update, unknown skipped tools) emit console warnings.
+
+## Maintenance reality
+
+This is an **internal, undocumented Anthropic endpoint** — no public docs, no stability guarantee. It is, however, a data contract that changes far less often than the DOM did (the old copy-button era was almost entirely "fix for Claude's UI changes" commits). If the export breaks, check whether the response shape above changed — that's the single point of coupling now. The script is **fully DOM-free**: no CSS selectors at all (the title comes from `conversationData.name`; `orgId` from a cookie; `conversationId` from the URL). Adding support for a new tool type is a one-line entry in `renderToolUse`.
+
+## Known scope limits (by design, per README)
+
+Exports every message's answer text plus its **content-bearing special elements** on the current branch: artifacts (reconstructed to their final version, rendered once), created files, and `visualize` widgets (charts/diagrams) as fenced code blocks. **Every other tool call is skipped** — web search, bash, file view/edit, and display widgets (maps, recipes, image/place search); their result URLs are ephemeral (the API flags them `is_expired`). Claude's internal `thinking` blocks are also skipped — **excluded by design, not deferred**: exploratory reasoning and discarded hypotheses pollute RAG retrieval and the document outline, and web search results would bake `is_expired` dead links into a document meant to stay useful offline. Treat requests to add either as out of scope (see issues #11 and #19). (`visualize:show_widget` and `create_file` have no revision model, so a "refined" widget/file is a new block and renders each time; only `artifacts` reconstruct.)
+
+Attachments: `describeAttachments()` renders each attachment above the message text, by what the API offers — `m.files` images → embed (`preview_url`); `m.files` documents → link (`document_asset.url`, `page_count`); `m.files` blobs (audio, no URL) → named; `m.attachments` text extractions (.md/.docx/…) → their `extracted_content` inlined as a **blockquote** (so the attachment's own headings stay quoted, out of the document outline). Each carries a word label — **`Attachment: <name> · <meta>`** (no emoji), consistent with `Artifact:`/`File:`/`Widget:`. Runs for **every** message, so an attachment-only turn is never dropped. Text content is inlined (self-contained/RAG-complete); the raw *binary* bytes are not — a portable ZIP bundling the originals is the deferred/premium step.

--- a/README.md
+++ b/README.md
@@ -1,44 +1,70 @@
 # Claude Chat Exporter
 
-A JavaScript tool that exports Claude.ai conversations with **perfect markdown fidelity** by leveraging Claude's native copy functionality. Get complete conversations with both human and AI messages including tables, complex formatting, and all elements that Claude supports.
+A JavaScript tool that exports Claude.ai conversations with **perfect markdown fidelity** by reading them straight from Claude's own internal API — the same endpoint the app itself uses. Get complete conversations with both human and AI messages including tables, math, code, and every element Claude supports, always in the right order. It runs entirely in your browser — the tool has **no server of its own**, and the only network call is to Claude's own backend (for your conversation), using your existing session.
+
+<p align="center">
+  <a href="https://agarwalvishal.github.io/claude-chat-exporter/">
+    <img src="https://img.shields.io/badge/▶%20Install-One--Click%20Bookmarklet-d97757?style=for-the-badge" alt="Install the one-click bookmarklet" />
+  </a>
+</p>
+
+## ⚡ One-Click Export (Bookmarklet)
+
+The easiest way — no console, no copy-paste, works for non-developers too:
+
+1. Open the **[one-click install page »](https://agarwalvishal.github.io/claude-chat-exporter/)**
+2. **Drag** the “📥 Claude Export” button onto your browser's bookmarks bar.
+3. Open any conversation on [claude.ai](https://claude.ai) and **click the bookmark** — your `.md` file downloads automatically.
+
+The bookmarklet is just this repository's open-source script wrapped into a link. It runs entirely in your browser — the tool has **no server of its own**, the only network call for your conversation is to Claude's own backend, and it stores nothing. The bookmarklet also checks for updates and shows an “update available” notice when a newer version is published, so you can re-drag to grab the latest.
+
+Prefer to run it yourself? See [Usage (Console)](#usage-console) below.
 
 ## Features
 
-- **🎯 Perfect Markdown Fidelity** - Uses Claude's copy function for exact output
-- **📊 Complete Element Support** - Tables, math, complex formatting, everything
-- **🕐 Timestamps** - Human message timestamps fetched from Claude's API
-- **📁 Smart Filename Generation** - Uses actual conversation title from API
-- **🔧 Future-Proof** - Automatically supports new Claude markdown features
-- **📈 Real-Time Status** - Visual progress indicator during export
-- **🛡️ Robust Error Handling** - Comprehensive error detection and recovery
-- **⚙️ Easy Maintenance** - Modular selectors for UI changes
+- **🎯 Perfect Markdown Fidelity** - Reads Claude's own source markdown from its API — no HTML parsing, no conversion. The result is a clean, faithful document that reads beautifully on its own
+- **📈 Complete Element Support** - Tables, math, code, lists, complex formatting — everything, byte-perfect
+- **🧩 Artifacts, Files & Widgets** - Artifacts (their final version), created files, and charts/diagrams are exported as clean fenced code blocks, in place and in order
+- **📎 Attachments** - Uploaded images embedded, documents linked, and text files inlined — exports stay self-contained
+- **🗂️ Obsidian- & RAG-ready** - YAML frontmatter + one heading per turn means it drops straight into an Obsidian vault or an AI/RAG pipeline — not just a plain dump ([more below](#obsidian--rag-ready))
+- **📊 Complete & In Order** - Every message on the current branch, correctly ordered — even in long conversations that only partly render on screen
+- **🕐 Timestamps** - Per-message timestamps for both human and Claude turns, from Claude's API
+- **🔒 Private by Design** - No servers, no tracking; runs in your browser and only ever calls Claude's own backend, over your existing session
+- **📁 Smart Filename Generation** - Uses the actual conversation title from the API
+- **🛡️ Robust to UI Changes** - Reads a stable data contract, not fragile CSS selectors
 
 ## How It Works
 
-1. **Fetch Metadata** - Calls Claude's internal API to retrieve the conversation title and per-message timestamps before anything is clicked
-2. **Human Messages** - Identifies human message action bars (those *without* a thumbs-up feedback button) and clicks their copy buttons; captures each clipboard write via an intercepted `navigator.clipboard.writeText`
-3. **Claude Responses** - Identifies Claude response action bars (those *with* a thumbs-up feedback button) and clicks their copy buttons; captures each clipboard write the same way
-4. **Perfect Output** - Combines both sets of captured content into a single markdown file, with timestamps on human message headers when available
+It's a single fetch, transformed into markdown:
 
-### Why Copy Button Approach?
+1. **Fetch** - Calls Claude's internal API for the current conversation (`/api/organizations/{orgId}/chat_conversations/{conversationId}`), authenticated by your existing session cookie. The response contains the title and every message.
+2. **Order** - Reconstructs the conversation's current branch by walking the message tree from the current leaf up its parent chain (so a regenerated response exports exactly what's on screen).
+3. **Extract** - Walks each message's content blocks in order: `text` blocks (Claude's original source markdown) plus special elements — artifacts, created files, and charts/diagrams/widgets — rendered in position; hidden/system messages are skipped.
+4. **Output** - Writes a single markdown file: YAML frontmatter (title, source, model, export date) followed by one `#`-level header per turn (`# Human — …` / `# Claude — …`) so Claude's own `##`/`###` content nests correctly beneath it. The result is a clean, faithful document that reads perfectly on its own — and the same structure makes it drop-in ready for [Obsidian & AI/RAG pipelines](#obsidian--rag-ready).
 
-Instead of manually parsing HTML and converting to markdown (which misses tables and complex elements), this tool uses **Claude's own copy button** to ensure 100% accurate markdown output for all message types.
+> **Branches / regenerated responses:** the export follows the branch Claude is currently showing — its *active leaf* — not necessarily the newest one. If you've regenerated a response and want to export a **different** branch, switch to that version in Claude first (the `‹ ›` arrows on a regenerated message), then run the exporter — the switch takes effect immediately, no page reload needed.
+
+### Why read the API instead of the page?
+
+Claude *generates* markdown, and the page only ever holds a small window of a long conversation in the DOM. Copy buttons hand over that markdown faithfully — but the DOM was still needed to *find* each message, work out who said it, and read the conversation title, and each of those is a CSS selector waiting to break. Reading the API gets **every message's source markdown directly**, along with the elements no copy button can reach.
 
 ```
-❌ Manual HTML Parsing:
-- Misses tables and complex elements
-- Requires constant updates for new features
-- Error-prone formatting conversion
-- Maintenance nightmare
+❌ Driving the page (DOM + copy buttons):
+- Only sees the messages currently rendered → long chats export partially
+- Pairs human and Claude turns by index → a regenerated branch can misalign them
+- Reaches only what has a copy button → no artifacts, files or attachments
+- Couples to CSS selectors that change constantly → a maintenance nightmare
 
-✅ Copy Button Method:
-- Perfect markdown fidelity
-- Automatic support for ALL elements
-- Future-proof against new features
-- Zero formatting edge cases
+✅ Reading Claude's API:
+- Complete conversation, always, in the order it appears on screen
+- Claude's original source markdown → perfect fidelity, zero conversion
+- Artifacts, created files, widgets and attachments come along too
+- A stable data contract instead of brittle selectors
 ```
 
-## Usage
+## Usage (Console)
+
+Prefer running it yourself, or want to tweak the script? Run it straight from the browser console:
 
 1. Open your conversation with Claude in your web browser.
 2. Open the browser's developer console:
@@ -46,12 +72,13 @@ Instead of manually parsing HTML and converting to markdown (which misses tables
    - Firefox: Press F12 or Ctrl+Shift+K (Windows/Linux) or Cmd+Option+K (Mac)
    - Safari: Enable the Develop menu in preferences, then press Cmd+Option+C
 3. Copy the entire script in the file `claude-chat-exporter.js` and paste it into the console.
+   - **First time?** Chrome, Edge, and Firefox block pasting into the console as a safety measure. If you see that warning, type `allow pasting`, press Enter, then paste the script again. (Only needed once per browser profile — the one-click bookmarklet skips this entirely.)
 4. Press Enter to run the script.
-5. The script will show a progress indicator and will automatically generate and download a file named `{conversation-title}.md` (auto-generated with `conversation-title` being the Claude conversation title).
+5. The script shows a small status indicator and automatically downloads a file named `{conversation-title}.md` (`conversation-title` being the Claude conversation title from the API).
 
 ## Complete Element Support
 
-Because this uses Claude's copy function, it automatically handles:
+Because this reads Claude's source markdown directly, it automatically handles:
 
 - ✅ **Tables** - Perfect markdown table formatting
 - ✅ **Math** - LaTeX and inline math notation
@@ -61,82 +88,84 @@ Because this uses Claude's copy function, it automatically handles:
 - ✅ **Formatting** - Bold, italic, strikethrough, etc.
 - ✅ **Blockquotes** - Proper quote formatting
 - ✅ **Headers** - All heading levels
+- ✅ **Artifacts** - Exported as a labelled fenced code block (final version), in place
+- ✅ **Created files** - `create_file` outputs, as a fenced code block with the filename
+- ✅ **Charts / diagrams / widgets** - `visualize` widgets exported as code (mermaid renders natively in Obsidian)
+- ✅ **Attachments** - Images embedded, documents linked, text files inlined
 - ✅ **Future elements** - Automatically supported
 
 ## File Output
 
-- **Filename**: `{conversation-title}.md` (from API, falls back to DOM)
-- **Format**: Perfect markdown matching Claude's copy output
-- **Content**: Complete conversation with proper spacing and timestamps
+- **Filename**: `{conversation-title}.md` (from the API title, else `claude_conversation`)
+- **Format**: YAML frontmatter + `#`-per-turn headers; bodies are Claude's own source markdown
+- **Content**: Complete conversation, in order, with per-message timestamps and inlined text-attachment content
 - **Encoding**: UTF-8 with standard line endings
 
 ## Example Output
 
-The output is **identical** to what you get when copying Claude messages manually, with timestamps added to human message headers:
+YAML frontmatter carries document metadata; each turn is an `#` header so Claude's own `##`/`###` headings nest beneath it. Attachments render above the text (text attachments are blockquoted, label and all); artifacts, created files, and widgets render in place as labelled fenced code blocks:
 
-```markdown
-# Conversation with Claude
-
-## Human (Feb 23, 2026, 10:30 AM):
-
-Can you create a comparison table of sorting algorithms?
-
+````markdown
+---
+title: "Sorting algorithm comparison"
+source: "https://claude.ai/chat/…"
+model: "claude-opus-4-…"
+exported: 2026-02-23
 ---
 
-## Claude:
+# Human — Feb 23, 2026, 10:30 AM
 
-Here's a comprehensive comparison table of sorting algorithms:
+> **Attachment: requirements.md · text/markdown · 1.2 KB**
+>
+> # Requirements
+> Compare the common sorting algorithms in a table.
 
-| Algorithm   | Best Case  | Average Case | Worst Case | Space    | Stable |
-| ----------- | ---------- | ------------ | ---------- | -------- | ------ |
-| Bubble Sort | O(n)       | O(n²)        | O(n²)      | O(1)     | Yes    |
-| Quick Sort  | O(n log n) | O(n log n)   | O(n²)      | O(log n) | No     |
-| Merge Sort  | O(n log n) | O(n log n)   | O(n log n) | O(n)     | Yes    |
+Can you create a comparison table, and a small React widget to visualise it?
 
-**Key advantages:**
+# Claude — Feb 23, 2026, 10:30 AM
 
-- Tables render perfectly ✅
-- Math notation preserved ✅
-- All formatting maintained ✅
+Here's the comparison and an interactive sorter:
 
----
+| Algorithm  | Best       | Average    | Worst      | Stable |
+| ---------- | ---------- | ---------- | ---------- | ------ |
+| Merge Sort | O(n log n) | O(n log n) | O(n log n) | Yes    |
+
+**Artifact: Sorting Visualiser · React**
+
+```jsx
+export default function Sorter() {
+  return <div>…</div>;
+}
 ```
 
-## Configuration
+# Human — Feb 23, 2026, 10:32 AM
 
-### Performance Tuning
+Now make it animated —
 
-Adjust the delay between copy button clicks in the `DELAYS` object:
+# Claude — Feb 23, 2026, 10:32 AM
 
-```javascript
-const DELAYS = {
-  copy: 100, // Delay between copy button clicks in ms (increase if messages are missed)
-};
-```
+Sure, adding an animation loop…
 
-Increasing `copy` can help on slower machines or when the page is under load. Decreasing it speeds up export but may cause clipboard writes to be missed.
+> **Interrupted:** this response was stopped before Claude finished.
+````
 
-### UI Selector Updates
+(The artifact shows its **final** version once; the `Interrupted` note appears only when a response was stopped. Everything is the source markdown Claude wrote — tables, code, and all — byte-for-byte.)
 
-If Claude's interface changes, update the `SELECTORS` object:
+## Obsidian & RAG ready
 
-```javascript
-const SELECTORS = {
-  copyButton: 'button[data-testid="action-bar-copy"]',
-  conversationTitle: '[data-testid="chat-title-button"] .truncate, button[data-testid="chat-title-button"] div.truncate, [data-testid="chat-title-split"] .truncate, [data-testid="chat-title-split"] button span.truncate',
-  messageActionsGroup: '[aria-label="Message actions"]',
-  feedbackButton: 'button[aria-label="Give positive feedback"], button[aria-label="Good response"]'
-};
-```
+First and foremost the export is a **clean, faithful Markdown document** — exactly the markdown Claude wrote, so it reads perfectly on its own. But unlike a plain dump, its structure is deliberately built to drop straight into your knowledge tools:
 
-The `feedbackButton` selector is what distinguishes Claude's action bars from human message action bars — it only appears on Claude's responses.
+- **YAML frontmatter** (`title`, `source`, `model`, `exported`) → Obsidian reads it as note **properties**; a RAG pipeline attaches it as per-document **metadata** on every chunk.
+- **One `#` heading per turn** → each Human/Claude turn is a clean top-level section, so heading-aware **RAG chunkers split neatly by turn**, and Claude's own `##`/`###` content nests *beneath* the turn instead of colliding with it.
+- **Blockquoted attachment text** → an attached doc's headings stay quoted, keeping your outline intact while the content stays fully searchable.
+- **Mermaid artifacts** render as **live diagrams** in Obsidian.
+- **Emoji-free body** → clean, consistent tokens for embeddings and search.
 
-## Performance Metrics
+Drop the `.md` into your vault or ingestion pipeline and it just works — no cleanup step. That structure is a real edge over exporters that hand you an unstructured wall of text.
 
-- **Execution Time**: 3-8 seconds for 10-message conversations
-- **Success Rate**: >95% with optimized delays
-- **Element Support**: 100% (matches Claude's copy functionality)
-- **Memory Usage**: Minimal (no large DOM processing)
+## Maintenance
+
+The script is **fully DOM-free** and the export is a single API read — there's nothing to configure. The one point of coupling is the shape of Claude's API response, handled in `getOrderedMessages()` / `renderToolUse()`: if Claude ever changes that response (or adds a new tool type), those functions are where to update, and the expected shape is documented in [`CLAUDE.md`](CLAUDE.md).
 
 ## Browser Compatibility
 
@@ -145,96 +174,116 @@ The `feedbackButton` selector is what distinguishes Claude's action bars from hu
 - ✅ Safari
 - ✅ Edge
 
-_Requires clipboard API support (available in all modern browsers)_
+_Works in any modern browser while you're logged in to claude.ai._
 
 ## Troubleshooting
 
 ### Export Status Indicators
 
-The script shows real-time progress:
+The script shows a small status box while it runs:
 
-- `Fetching conversation data...` - Retrieving title and timestamps from API
-- `Copying human messages...` - Clicking human message copy buttons
-- `Copying Claude responses...` - Clicking Claude response copy buttons
-- `Human: X | Claude: Y` - Live capture counts
-- `✅ Downloaded: filename.md` - Success!
+- `Fetching conversation…` - Reading the conversation from Claude's API
+- `✅ Exported N messages: filename.md` - Success!
+- `⚠️ Exported N messages (some responses incomplete): filename.md` - Success, but one or more messages were interrupted or truncated in the source data (each is flagged inline)
+- `Error: …` - Something went wrong (details in the console)
 
 ### Common Issues
 
-**No Messages Captured**
+**Could not fetch conversation data**
 
-- Ensure conversation is fully loaded
-- Check that messages are visible on screen
-- Try scrolling through entire conversation first
+- Make sure you're logged in to claude.ai and the conversation URL is open
+- Reload the page and run again
 
-**Partial Export**
+**No messages found**
 
-- Script shows exact counts: "Human: 3 | Claude: 2"
-- If mismatch, some messages may not be accessible
-- Try refreshing page and running again
+- The conversation may be empty, or still opening — reload and retry
+
+You do **not** need to scroll the conversation first — the whole thread is read from the API regardless of what's rendered on screen.
 
 ## Technical Architecture
 
-### Two-Phase Copy Button Capture
+The whole script is one closure, `setupClaudeExporter()`, running a small pipeline: `fetchConversationData()` → `getOrderedMessages()` → `buildMarkdown()` → download.
 
-Human and Claude message action bars are structurally identical except that Claude's bars include a thumbs-up feedback button. `getCopyButtons` uses this to filter:
+### The API response
 
-```javascript
-function getCopyButtons(claudeOnly) {
-  const actionGroups = document.querySelectorAll(SELECTORS.messageActionsGroup);
-  const buttons = [];
-  actionGroups.forEach(group => {
-    const hasFeedback = !!group.querySelector(SELECTORS.feedbackButton);
-    if (hasFeedback === claudeOnly) {
-      const copyBtn = group.querySelector(SELECTORS.copyButton);
-      if (copyBtn) buttons.push(copyBtn);
-    }
-  });
-  return buttons;
+```
+GET /api/organizations/{orgId}/chat_conversations/{conversationId}?tree=true&rendering_mode=messages&render_all_tools=true
+```
+
+`orgId` comes from the `lastActiveOrg` cookie, `conversationId` from the URL path; the request is same-origin and uses your session cookie. The relevant response shape:
+
+```jsonc
+{
+  "name": "…",                       // conversation title
+  "model": "…",                      // e.g. claude-opus-5 (frontmatter)
+  "current_leaf_message_uuid": "…",  // tip of the current branch
+  "chat_messages": [{
+    "uuid": "…", "parent_message_uuid": "…",  // tree links
+    "index": 0,                               // fallback ordering
+    "sender": "human" | "assistant",
+    "created_at": "…",                        // ISO timestamp
+    "truncated": false,
+    "content": [{ "type": "text" | "thinking" | "tool_use" | "tool_result", "text": "…" }],
+    "files": [ /* uploaded images/docs */ ], "attachments": [ /* text extractions */ ]
+  }]
 }
 ```
 
-`startExport` then runs two sequential phases, switching `currentCapture` between `humanMessages` and `capturedResponses` so the clipboard interceptor routes each write to the right array:
+`tool_use` blocks carry `name` + `input`; the exporter renders `artifacts`, `create_file`,
+and `visualize:show_widget` from their `input`. The full field-level contract (files,
+attachments, and each tool's `input` shape) is documented in [`CLAUDE.md`](CLAUDE.md).
+
+### Ordering (current branch)
+
+Messages form a tree. `getOrderedMessages()` follows the branch actually on screen by walking from `current_leaf_message_uuid` up the `parent_message_uuid` chain and reversing, falling back to sorting by `index`:
 
 ```javascript
-// Phase 1: Human messages
-currentCapture = humanMessages;
-await triggerCopyButtons(humanButtons);
-await waitForClipboardOperations(humanMessages, humanButtons.length);
-
-// Phase 2: Claude responses
-currentCapture = capturedResponses;
-await triggerCopyButtons(claudeButtons);
-await waitForClipboardOperations(capturedResponses, claudeButtons.length);
+let cur = byUuid.get(data.current_leaf_message_uuid);
+while (cur) { path.push(cur); cur = byUuid.get(cur.parent_message_uuid); }
+path.reverse();
 ```
 
-### Clipboard Interception
+### Content extraction
+
+Each message's `content` interleaves typed blocks. We walk them **in order**, emitting `text` blocks plus content-bearing `tool_use` blocks (via `renderToolUse`), so text and special elements stay interleaved as written; `thinking` and `tool_result` blocks are skipped, as are messages that end up empty:
 
 ```javascript
-navigator.clipboard.writeText = function(text) {
-  if (interceptorActive && text) {
-    const type = currentCapture === humanMessages ? 'user' : 'claude';
-    currentCapture.push({ type, content: text });
-  }
-};
+const parts = [];
+for (const block of (m.content || [])) {
+  if (block.type === 'text' && typeof block.text === 'string') parts.push(block.text.trim());
+  else if (block.type === 'tool_use') parts.push(renderToolUse(block, artifacts));
+}
 ```
 
-### Timestamp Matching
+`renderToolUse` renders **artifacts**, **created files** (`create_file`), and **charts/diagrams/widgets** (`visualize:show_widget`) as titled fenced code blocks with a kind label (`Artifact:` / `File:` / `Widget:`; language mapped from type/extension; `mermaid` renders natively in Obsidian). Artifacts are reconstructed to their final version (folding create + edits) and rendered once, at their last edit. **Every other tool** — web search, bash, file view/edit, display widgets — is skipped.
 
-Timestamps are fetched from Claude's internal API and stored in a `Map<content → timestamp>`. Matching by content (rather than by index) ensures correctness even when the API returns hidden or system messages alongside visible ones:
+This is Claude's original source markdown, so tables/math/code are byte-perfect with no conversion.
 
-```javascript
-const ts = timestamps?.get(humanMessages[i].content?.trim());
-const header = ts ? `## Human (${ts}):` : `## Human:`;
-```
+## Advantages Over Other Methods
 
-## Advantages Over Manual Methods
+| Method                        | Accuracy | Completeness            | Maintenance |
+| ----------------------------- | -------- | ----------------------- | ----------- |
+| **This Script (API)**         | 100%     | Whole conversation      | Low         |
+| Manual Copy/Paste             | 100%     | Whatever you scroll to  | N/A         |
+| DOM scraping / copy buttons   | ~high    | Only rendered messages  | High        |
+| HTML → markdown parsers       | ~80%     | Only rendered messages  | High        |
 
-| Method               | Accuracy | Speed     | Maintenance | Future-Proof |
-| -------------------- | -------- | --------- | ----------- | ------------ |
-| **This Script**      | 100%     | Fast      | Low         | Yes          |
-| Manual Copy/Paste    | 100%     | Very Slow | N/A         | Yes          |
-| HTML Parsing Scripts | ~80%     | Fast      | High        | No           |
+## Privacy & Security
+
+- **No Backend of Its Own** - This tool runs no servers; your conversations are never sent to us or any other party
+- **Runs in Your Browser** - All processing happens locally on your machine
+- **Claude's Own API Only** - The single request reads *your* conversation from Claude's own backend, over your existing session — the same data claude.ai already loads for you
+- **No Data Storage** - Messages are transformed and downloaded immediately; nothing is retained
+
+The bookmarklet additionally fetches its own script and an update check from GitHub — these read public files and send none of your conversation data.
+
+## Limitations
+
+- **Requires JavaScript** - Must be enabled in browser
+- **Claude Web Only** - Works only on claude.ai web interface, while you're logged in
+- **Undocumented API** - Relies on Claude's internal API; a change to its response shape would require an update (rare, and far less brittle than CSS selectors)
+- **Special elements** - Artifacts (their final version), created files, and charts/diagrams/widgets are exported as fenced code blocks. Not exported: other tool calls (web search, bash, file view/edit), display widgets (maps, recipes, image/place search — their result URLs are ephemeral), and Claude's internal thinking blocks (excluded by design — exploratory reasoning and discarded hypotheses pollute RAG retrieval and the document outline)
+- **Attachments** - Every attachment is represented, above the text: **images** embedded, **documents** (PDF) linked (`document · N pages`), **blobs** (audio, etc.) named, and **text attachments** (.md/.docx/.txt/.html) inlined as a blockquote of their extracted text — so exports stay self-contained and RAG-complete. Not exported: the raw *binary* bytes (image/PDF/audio), and file links are auth-gated claude.ai URLs that load only while signed in to the same account. A portable ZIP that bundles the binary originals is a possible future addition
 
 ## Contributing
 
@@ -242,26 +291,9 @@ Contributions to improve the script or add new features are welcome! Please feel
 
 This project benefits from:
 
-1. **Selector Updates** - Help maintain compatibility with UI changes
-2. **Performance Tuning** - Optimize delays for different browsers
-3. **Error Handling** - Improve robustness for edge cases
-4. **Handling Additional Elements** - Handle exporting artifacts, attachments, etc.
-
-## Limitations
-
-- **Requires JavaScript** - Must be enabled in browser
-- **Claude Web Only** - Works only on claude.ai web interface
-- **Susceptible to DOM changes** - Interface changes may require updates to CSS selectors
-- **Visible Messages** - Only exports messages visible in DOM
-- **No Attachments** - Cannot export uploaded files or images
-- **No Artifacts** - Artifact content is currently skipped
-
-## Privacy & Security
-
-- **Local Processing** - Everything runs in your browser
-- **Same-Origin API Only** - Fetches metadata from Claude's own backend using your existing session; no third-party services involved
-- **Temporary Interception** - Clipboard restored after export
-- **No Data Storage** - Messages processed and downloaded immediately
+1. **API Contract Updates** - Help keep `getOrderedMessages()` in sync if Claude's API response changes
+2. **Error Handling** - Improve robustness for edge cases
+3. **Additional Content** - Richer display-widget rendering, or bundling binary attachment/file originals
 
 ## License
 

--- a/claude-chat-exporter.js
+++ b/claude-chat-exporter.js
@@ -1,117 +1,353 @@
+// Claude Chat Exporter — exports a claude.ai conversation to a markdown file.
+//
+// Approach: read the conversation straight from claude.ai's own internal API
+// (the same endpoint the app uses), which returns every message's *source
+// markdown* — tables, math, code, and all — in order, complete, with an explicit
+// human/assistant label. There is no DOM scraping, no copy-button clicking, no
+// clipboard interception, and no scrolling: a single same-origin fetch (using the
+// user's existing session) is transformed into markdown and downloaded.
+//
+// Why not the DOM? The rendered page is a lossy derivative of this markdown, only
+// shows a virtualized window of long conversations, and couples the script to
+// CSS selectors that change constantly. The API is a far more stable data
+// contract. See CLAUDE.md for the response shape.
 function setupClaudeExporter() {
-  const originalWriteText = navigator.clipboard.writeText;
-  const capturedResponses = [];
-  const humanMessages = [];
   let conversationData = null;
-  let currentCapture = capturedResponses;
-  let interceptorActive = true;
 
-  // DOM Selectors - easily modifiable if Claude's UI changes
-  const SELECTORS = {
-    copyButton: 'button[data-testid="action-bar-copy"]',
-    conversationTitle: '[data-testid="chat-title-button"] .truncate, button[data-testid="chat-title-button"] div.truncate, [data-testid="chat-title-split"] .truncate, [data-testid="chat-title-split"] button span.truncate',
-    messageActionsGroup: '[aria-label="Message actions"]',
-    feedbackButton: 'button[aria-label="Give positive feedback"], button[aria-label="Good response"]'
-  };
-
-  const DELAYS = {
-    copy: 100
-  };
+  // Non-fatal warnings collected during the run — logged to the console and
+  // summarised in the status box, so a degraded export never looks fully clean.
+  const warnings = [];
+  const warn = (msg) => { console.warn(msg); warnings.push(msg); };
+  // tool_use names that were skipped (not rendered) — logged once, to help spot a
+  // new content-bearing tool the registry should learn about.
+  const skippedTools = new Set();
 
   function downloadMarkdown(content, filename) {
     const blob = new Blob([content], { type: 'text/markdown' });
     const a = document.createElement('a');
     a.href = URL.createObjectURL(blob);
-    a.download = filename;
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-    URL.revokeObjectURL(a.href);
+    try {
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+    } finally {
+      URL.revokeObjectURL(a.href); // revoke even if the click throws (avoids a leak)
+    }
   }
 
-  function delay(ms) {
-    return new Promise(resolve => setTimeout(resolve, ms));
-  }
-
-  // Format ISO timestamp to readable format
+  // Format ISO timestamp to a readable format
   function formatTimestamp(isoString) {
     if (!isoString) return null;
-    return new Date(isoString).toLocaleString('en-US', {
+    const date = new Date(isoString);
+    if (isNaN(date.getTime())) return null; // don't leak "Invalid Date" into a header
+    return date.toLocaleString('en-US', {
       month: 'short', day: 'numeric', year: 'numeric',
       hour: 'numeric', minute: '2-digit'
     });
   }
 
-  // Fetch conversation data from Claude API to get timestamps
+  // Fetch the full conversation from Claude's internal API. Same-origin request
+  // authenticated by the user's existing session cookie; returns title, ordered
+  // messages, per-message timestamps and content blocks. See CLAUDE.md.
   async function fetchConversationData() {
+    const conversationId = window.location.pathname.split('/').pop();
+    const orgId = document.cookie.match(/lastActiveOrg=([^;]+)/)?.[1];
+
+    // A Claude conversation id is a UUID; anything else (e.g. /new, /projects) means
+    // the user isn't on a specific conversation.
+    if (!conversationId || conversationId.length < 20 || !conversationId.includes('-')) {
+      throw new Error('Open a specific Claude conversation first (the current page has no conversation id).');
+    }
+    if (!orgId) {
+      throw new Error("Couldn't read your Claude session (lastActiveOrg cookie missing) — are you signed in?");
+    }
+
+    const url = `/api/organizations/${orgId}/chat_conversations/${conversationId}?tree=true&rendering_mode=messages&render_all_tools=true`;
+
+    let response;
     try {
-      const conversationId = window.location.pathname.split('/').pop();
-      const orgId = document.cookie.match(/lastActiveOrg=([^;]+)/)?.[1];
-
-      if (!conversationId || !orgId) {
-        console.warn('Could not get conversation/org ID');
-        return null;
-      }
-
-      const url = `/api/organizations/${orgId}/chat_conversations/${conversationId}?tree=true&rendering_mode=messages&render_all_tools=true`;
-
-      const response = await fetch(url, {
+      response = await fetch(url, {
         credentials: 'include',
         headers: { 'Content-Type': 'application/json' }
       });
+    } catch (error) {
+      throw new Error(`Couldn't reach the Claude API: ${error.message}`);
+    }
 
-      if (!response.ok) {
-        console.warn(`API error: ${response.status}`);
-        return null;
-      }
+    if (!response.ok) {
+      const hint = (response.status === 401 || response.status === 403)
+        ? ' — your session may have expired; reload and sign in'
+        : '';
+      throw new Error(`Claude API request failed (HTTP ${response.status})${hint}.`);
+    }
 
+    try {
       return await response.json();
     } catch (error) {
-      console.warn('Failed to fetch conversation data:', error);
-      return null;
+      throw new Error(`Couldn't parse the Claude API response: ${error.message}`);
     }
   }
 
-  // Build a content → timestamp map for human messages from API response.
-  // Matching by content avoids index misalignment caused by hidden/system
-  // messages that the API returns but the UI does not display.
-  function getMessageTimestamps(data) {
-    const map = new Map();
-    if (!data?.chat_messages) return map;
+  // Turn the API response into an ordered list of visible turns:
+  // [{ sender, text, created_at, truncated, stop_reason }] in conversation order.
+  //
+  // Ordering: the API returns a message *tree*. We follow the current branch by
+  // walking from current_leaf_message_uuid up the parent_message_uuid chain and
+  // reversing — this exports exactly the path shown on screen even when a
+  // response was regenerated. Falls back to sorting by `index` if the leaf is
+  // missing.
+  //
+  // Content: a message's `content` is an array of typed blocks (text, thinking,
+  // tool_use, tool_result). We walk them in order, emitting `text` blocks plus the
+  // content-bearing `tool_use` blocks (artifacts / created files / widgets, via
+  // renderToolUse) so text and special elements stay interleaved; `thinking` and
+  // `tool_result` are skipped. Messages that end up empty are dropped (the API also
+  // returns hidden/system messages the UI never shows).
+  function getOrderedMessages(data) {
+    const all = data?.chat_messages || [];
+    if (!all.length) return [];
 
-    for (const msg of data.chat_messages) {
-      if (msg.sender === 'human') {
-        const text = msg.content?.map(c => c.text ?? '').join('').trim();
-        if (text) map.set(text, formatTimestamp(msg.created_at));
+    const byUuid = new Map(all.map(m => [m.uuid, m]));
+    let ordered = null;
+
+    const leaf = data.current_leaf_message_uuid;
+    if (leaf && byUuid.has(leaf)) {
+      const path = [];
+      const seen = new Set();
+      let cur = byUuid.get(leaf);
+      while (cur && !seen.has(cur.uuid)) {
+        seen.add(cur.uuid);
+        path.push(cur);
+        cur = cur.parent_message_uuid ? byUuid.get(cur.parent_message_uuid) : null;
       }
+      if (path.length) ordered = path.reverse();
     }
 
-    return map;
+    if (!ordered) {
+      warn('Could not resolve the current branch (current_leaf_message_uuid missing/unresolved) — falling back to index order, which may be inaccurate for branched conversations.');
+      ordered = [...all].sort((a, b) => (a.index ?? 0) - (b.index ?? 0));
+    }
+
+    // Reconstruct each artifact's final state up-front so it can be rendered once,
+    // at its last edit (see collectArtifacts / renderToolUse).
+    const artifacts = collectArtifacts(ordered);
+
+    const messages = [];
+    const unexpectedSenders = new Set();
+    for (const m of ordered) {
+      if (m.sender != null && m.sender !== 'human' && m.sender !== 'assistant') {
+        unexpectedSenders.add(m.sender);
+      }
+
+      // Walk the content blocks in order so text and special elements (artifacts,
+      // created files, charts/widgets) stay interleaved exactly as written. Only
+      // `text` blocks and content-bearing `tool_use` blocks produce output;
+      // `thinking` and `tool_result` blocks are skipped.
+      const parts = [];
+      for (const block of (m.content || [])) {
+        if (block.type === 'text' && typeof block.text === 'string') {
+          parts.push(block.text.trim());
+        } else if (block.type === 'tool_use') {
+          parts.push(renderToolUse(block, artifacts));
+        }
+      }
+
+      // Message-level uploads (images/docs the human attached) sit above the text,
+      // mirroring the UI; prepend them, then the in-order content parts.
+      const attachments = describeAttachments(m);
+      const text = [attachments, ...parts].filter(Boolean).join('\n\n').trim();
+
+      if (!text) continue; // genuinely empty (hidden/system) message
+
+      messages.push({
+        sender: m.sender,
+        text,
+        created_at: m.created_at,
+        truncated: !!m.truncated,
+        stop_reason: m.stop_reason
+      });
+    }
+
+    if (unexpectedSenders.size) {
+      warn(`Unexpected sender value(s): ${[...unexpectedSenders].join(', ')} — labelled as "Claude".`);
+    }
+    if (skippedTools.size) {
+      // Debug level: hidden from normal users (Chrome shows it only in "Verbose"),
+      // but lets a maintainer spot a new content-bearing tool the registry should handle.
+      console.debug('[claude-chat-exporter] tools skipped (not rendered):', [...skippedTools].join(', '));
+    }
+
+    return messages;
   }
 
-  function getConversationTitle() {
-    // First try to get from API data
-    if (conversationData?.name) {
-      const title = conversationData.name.trim();
-      if (title && title !== 'New conversation') {
-        return title
-          .replace(/[<>:"/\\|?*]/g, '_')
-          .replace(/\s+/g, '_')
-          .replace(/_{2,}/g, '_')
-          .replace(/^_+|_+$/g, '')
-          .toLowerCase()
-          .substring(0, 100);
+  // Human-readable byte size, e.g. "4.7 KB".
+  function formatBytes(n) {
+    if (n == null || isNaN(n)) return null;
+    if (n < 1024) return `${n} B`;
+    if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+    return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+  }
+
+  // Represent a message's attachments as markdown, placed above its text.
+  //
+  // The API stores attachments in two places, handled by what each actually offers:
+  //   • m.files       — uploaded files. Images carry a preview_url (embedded);
+  //                     documents (e.g. PDF) carry document_asset.url (linked);
+  //                     blobs (e.g. audio) have no usable URL (named marker).
+  //   • m.attachments — text extractions (.md/.docx/.txt/.html/…). No URL, but the
+  //                     extracted text itself is present, so it is inlined as a
+  //                     blockquote — its own headings stay quoted, keeping them out
+  //                     of the document outline. This is what makes an export
+  //                     self-contained for reading and for RAG.
+  //
+  // File URLs are same-origin claude.ai endpoints: they load only while signed in
+  // to the same account. Bundling the binary originals is left for later.
+  function describeAttachments(m) {
+    const toAbsolute = (u) => {
+      if (!u || typeof u !== 'string') return null;
+      try { return new URL(u, 'https://claude.ai').href; } catch { return null; }
+    };
+    const meta = (...bits) => bits.filter(Boolean).join(' · ');
+
+    const parts = [];
+
+    for (const file of (m.files || [])) {
+      const name = file.file_name || 'file';
+
+      if (file.file_kind === 'image') {
+        const url = toAbsolute(file.preview_url || file.preview_asset?.url);
+        const label = `**Attachment: ${meta(name, 'image')}**`;
+        parts.push(url ? `${label}\n\n![${name}](${url})` : label);
+      } else if (file.file_kind === 'document') {
+        const url = toAbsolute(file.document_asset?.url);
+        const pages = file.document_asset?.page_count;
+        const info = meta('document', pages ? `${pages} page${pages === 1 ? '' : 's'}` : null);
+        const nameLink = url ? `[${name}](${url})` : name;
+        parts.push(`**Attachment: ${meta(nameLink, info)}**`);
+      } else {
+        // blob or unknown kind — no reliable URL to link to
+        parts.push(`**Attachment: ${meta(name, file.file_kind, formatBytes(file.size_bytes))}**`);
       }
     }
 
-    // Fallback to DOM
-    const titleElement = document.querySelector(SELECTORS.conversationTitle);
-    const title = titleElement?.textContent?.trim();
+    for (const attachment of (m.attachments || [])) {
+      const name = attachment.file_name || attachment.name || 'attachment';
+      const info = meta(attachment.file_type, formatBytes(attachment.file_size));
+      const label = `**Attachment: ${meta(name, info)}**`;
+      const content = typeof attachment.extracted_content === 'string'
+        ? attachment.extracted_content.trim()
+        : '';
 
-    if (!title || title === 'Claude' || title.includes('New conversation')) {
-      return 'claude_conversation';
+      const lines = [label];
+      if (content) {
+        lines.push('');
+        for (const line of content.split('\n')) lines.push(line);
+      }
+      // Quote the whole block so the attachment's own headings don't enter the outline
+      parts.push(lines.map(line => (line ? `> ${line}` : '>')).join('\n'));
     }
 
+    return parts.join('\n\n');
+  }
+
+  // Fold every artifact (keyed by `id`) into its final state. The `artifacts` tool is
+  // the only element with a revision model: `create`/`rewrite` carry full `content`;
+  // `update` carries an `old_str`→`new_str` diff. We apply them in order and remember
+  // the `version_uuid` of each artifact's LAST block, so renderToolUse can emit it once,
+  // at its final edit. (Widgets and created files have no linking id and are rendered
+  // as-is, each occurrence.)
+  function collectArtifacts(ordered) {
+    const artifacts = new Map();
+    for (const m of ordered) {
+      for (const block of (m.content || [])) {
+        if (block.type !== 'tool_use' || block.name !== 'artifacts') continue;
+        const input = block.input || {};
+        const id = input.id || '__artifact__';
+        let a = artifacts.get(id);
+        if (!a) { a = { content: '' }; artifacts.set(id, a); }
+
+        if (input.command === 'update') {
+          if (typeof input.old_str === 'string' && typeof input.new_str === 'string') {
+            if (a.content.indexOf(input.old_str) === -1) {
+              warn(`Artifact "${a.title || id}": an update couldn't be applied (source text not found) — its content may be incomplete.`);
+            } else {
+              // Function replacer, not a string: a plain string would interpret `$&`,
+              // "$`", `$'` and `$$` in new_str as replacement patterns and silently
+              // corrupt the artifact (such sequences occur in real code).
+              a.content = a.content.replace(input.old_str, () => input.new_str);
+            }
+          }
+        } else if (typeof input.content === 'string') {
+          a.content = input.content; // create / rewrite → full content
+        }
+        if (input.title) a.title = input.title;      // metadata lives on the create block
+        if (input.type) a.type = input.type;
+        if (input.language) a.language = input.language;
+        a.lastVersionUuid = input.version_uuid;      // last write wins → finalization block
+      }
+    }
+
+    for (const [id, a] of artifacts) {
+      if (!a.content) warn(`Artifact "${a.title || id}" ended up empty — it may not have exported.`);
+    }
+    return artifacts;
+  }
+
+  // Render a `tool_use` block. Only the three content-bearing tools produce output —
+  // artifacts, created files, and visualize widgets (charts/diagrams) — each as a
+  // titled fenced code block with a kind label drawn from the API. Every other tool
+  // (web search, bash, file view/edit, display widgets, unknown) is skipped. Artifacts
+  // render once, at their final edit; the reconstructed content comes from `artifacts`.
+  function renderToolUse(block, artifacts) {
+    const input = block.input || {};
+    const name = block.name || '';
+
+    // A code fence longer than any backtick run in the source (avoids collisions).
+    const fenceFor = (src) => '`'.repeat(Math.max(3, ...(src.match(/`+/g) || []).map(s => s.length + 1)));
+    const codeBlock = (label, source, lang) => {
+      const fence = fenceFor(source);
+      return `**${label}**\n\n${fence}${lang || ''}\n${source}\n${fence}`;
+    };
+
+    if (name === 'artifacts') {
+      const a = artifacts.get(input.id || '__artifact__');
+      // Only the final edit renders; earlier create/update/rewrite blocks emit nothing.
+      if (!a || input.version_uuid !== a.lastVersionUuid || !a.content) return '';
+      const TYPE = {
+        'application/vnd.ant.react': { lang: 'jsx', label: 'React' },
+        'text/html': { lang: 'html', label: 'HTML' },
+        'image/svg+xml': { lang: 'svg', label: 'SVG' },
+        'application/vnd.ant.mermaid': { lang: 'mermaid', label: 'Mermaid' },
+        'text/markdown': { lang: 'markdown', label: 'Markdown' },
+        'application/vnd.ant.code': { lang: a.language || '', label: a.language || 'Code' }
+      };
+      const t = TYPE[a.type] || { lang: a.language || '', label: a.language || '' };
+      const label = `Artifact: ${a.title || 'untitled'}${t.label ? ` · ${t.label}` : ''}`;
+      return codeBlock(label, a.content, t.lang);
+    }
+
+    if (name === 'create_file' && typeof input.file_text === 'string' && input.file_text) {
+      const file = String(input.path || 'file').split('/').pop();
+      const ext = file.includes('.') ? file.split('.').pop().toLowerCase() : '';
+      const EXT_LANG = {
+        py: 'python', js: 'javascript', jsx: 'jsx', ts: 'typescript', tsx: 'tsx',
+        md: 'markdown', html: 'html', css: 'css', json: 'json', sh: 'bash',
+        yml: 'yaml', yaml: 'yaml', sql: 'sql', java: 'java', rb: 'ruby', go: 'go',
+        rs: 'rust', c: 'c', cpp: 'cpp', txt: ''
+      };
+      return codeBlock(`File: ${file}`, input.file_text, EXT_LANG[ext] ?? '');
+    }
+
+    if (name === 'visualize:show_widget' && typeof input.widget_code === 'string' && input.widget_code) {
+      return codeBlock(`Widget: ${input.title || 'untitled'}`, input.widget_code, 'jsx');
+    }
+
+    if (name) skippedTools.add(name); // every other tool is skipped; track for visibility
+    return '';
+  }
+
+  function sanitizeTitle(title) {
     return title
       .replace(/[<>:"/\\|?*]/g, '_')
       .replace(/\s+/g, '_')
@@ -121,17 +357,69 @@ function setupClaudeExporter() {
       .substring(0, 100);
   }
 
-  // Intercept clipboard writes and route to the active capture target
-  navigator.clipboard.writeText = function(text) {
-    if (interceptorActive && text) {
-      const type = currentCapture === humanMessages ? 'user' : 'claude';
-      console.log(`📋 Captured ${type} message ${currentCapture.length + 1}`);
-      currentCapture.push({ type, content: text });
-      updateStatus();
+  function getConversationTitle() {
+    const title = conversationData?.name?.trim();
+    if (title && title !== 'New conversation') {
+      // A punctuation-only title (e.g. "***") sanitizes to '' — don't emit ".md".
+      return sanitizeTitle(title) || 'claude_conversation';
     }
-  };
+    return 'claude_conversation';
+  }
 
-  // Create status indicator
+  // YAML double-quoted scalar (escapes backslashes and quotes).
+  function yamlString(value) {
+    return '"' + String(value ?? '').replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"';
+  }
+
+  // A word-based notice appended to an incomplete message (or '' when complete). Only the
+  // two signals verified in the API are flagged: `truncated` (rare source-data content
+  // truncation) and `stop_reason: 'user_canceled'` (the user stopped the response).
+  function incompleteNote(message) {
+    if (message.truncated) {
+      return '> **Truncated:** the message was truncated in the source data and may be incomplete.';
+    }
+    if (message.stop_reason === 'user_canceled') {
+      return '> **Interrupted:** this response was stopped before Claude finished.';
+    }
+    return '';
+  }
+
+  // Output shape (tuned for RAG ingestion and Obsidian):
+  //   • YAML frontmatter carries doc-level metadata (title, source, model, date)
+  //     — Obsidian reads it as properties; RAG attaches it to every chunk.
+  //   • Each turn is an H1 header, so Claude's own ##/### content nests beneath it
+  //     and turn boundaries are the top split level. (No separate title heading or
+  //     `---` rules — the frontmatter and headers already delimit everything.)
+  function buildMarkdown(messages) {
+    const title = conversationData?.name?.trim() || 'Claude conversation';
+    const source = window.location.origin + window.location.pathname;
+
+    const frontMatter = ['---', `title: ${yamlString(title)}`, `source: ${yamlString(source)}`];
+    if (conversationData?.model) frontMatter.push(`model: ${yamlString(conversationData.model)}`);
+    frontMatter.push(`exported: ${new Date().toISOString().slice(0, 10)}`, '---', '');
+
+    let markdown = frontMatter.join('\n') + '\n';
+    let anyIncomplete = false;
+
+    for (const message of messages) {
+      const who = message.sender === 'human' ? 'Human' : 'Claude';
+      const ts = formatTimestamp(message.created_at);
+      const header = ts ? `# ${who} — ${ts}` : `# ${who}`;
+
+      let body = message.text;
+      const note = incompleteNote(message);
+      if (note) {
+        anyIncomplete = true;
+        body += `\n\n${note}`;
+      }
+
+      markdown += `${header}\n\n${body}\n\n`;
+    }
+
+    return { markdown, anyIncomplete };
+  }
+
+  // Status indicator
   const statusDiv = document.createElement('div');
   statusDiv.style.cssText = `
     position: fixed; top: 10px; right: 10px; z-index: 10000;
@@ -141,156 +429,53 @@ function setupClaudeExporter() {
   `;
   document.body.appendChild(statusDiv);
 
-  function updateStatus() {
-    statusDiv.textContent = `Human: ${humanMessages.length} | Claude: ${capturedResponses.length}`;
-  }
-
-  // Returns copy buttons from action bars filtered by message type.
-  // claudeOnly=true  → action bars WITH a feedback button (Claude responses)
-  // claudeOnly=false → action bars WITHOUT a feedback button (human messages)
-  function getCopyButtons(claudeOnly) {
-    const actionGroups = document.querySelectorAll(SELECTORS.messageActionsGroup);
-    const buttons = [];
-    actionGroups.forEach(group => {
-      const hasFeedback = !!group.querySelector(SELECTORS.feedbackButton);
-      if (hasFeedback === claudeOnly) {
-        const copyBtn = group.querySelector(SELECTORS.copyButton);
-        if (copyBtn) buttons.push(copyBtn);
-      }
-    });
-    return buttons;
-  }
-
-  async function triggerCopyButtons(buttons) {
-    for (let i = 0; i < buttons.length; i++) {
-      try {
-        if (buttons[i].offsetParent !== null) {
-          buttons[i].scrollIntoView({ behavior: 'instant', block: 'nearest' });
-          buttons[i].click();
-          console.log(`🖱️ Clicked copy button ${i + 1}/${buttons.length}`);
-        }
-      } catch (error) {
-        console.warn(`Failed to click button ${i + 1}:`, error);
-      }
-
-      // Only delay between clicks, not after the last one
-      if (i < buttons.length - 1) {
-        await delay(DELAYS.copy);
-      }
+  function cleanup() {
+    if (document.body.contains(statusDiv)) {
+      document.body.removeChild(statusDiv);
     }
-  }
-
-  function buildMarkdown(timestamps) {
-    let markdown = "# Conversation with Claude\n\n";
-    const maxLength = Math.max(humanMessages.length, capturedResponses.length);
-
-    for (let i = 0; i < maxLength; i++) {
-      if (i < humanMessages.length && humanMessages[i].content) {
-        const ts = timestamps?.get(humanMessages[i].content?.trim());
-        const header = ts ? `## Human (${ts}):` : `## Human:`;
-        markdown += `${header}\n\n${humanMessages[i].content}\n\n---\n\n`;
-      }
-      if (i < capturedResponses.length) {
-        markdown += `## Claude:\n\n${capturedResponses[i].content}\n\n---\n\n`;
-      }
-    }
-
-    return markdown;
-  }
-
-  async function waitForClipboardOperations(targetArray, expectedCount) {
-    const maxWaitTime = 2000;
-    const checkInterval = 100;
-    let elapsed = 0;
-
-    while (elapsed < maxWaitTime) {
-      if (targetArray.length >= expectedCount) {
-        console.log(`✅ All ${expectedCount} responses captured in ${elapsed}ms`);
-        return;
-      }
-      await delay(checkInterval);
-      elapsed += checkInterval;
-    }
-
-    console.warn(`⚠️ Timeout: Only captured ${targetArray.length}/${expectedCount} responses`);
   }
 
   async function startExport() {
     try {
-      // Fetch conversation data from API (for timestamps and title)
-      statusDiv.textContent = 'Fetching conversation data...';
+      statusDiv.textContent = 'Fetching conversation…';
       conversationData = await fetchConversationData();
-      const timestamps = getMessageTimestamps(conversationData);
 
-      if (conversationData) {
-        console.log(`📅 Got timestamps for ${timestamps.size} human messages`);
+      // Validate the response shape — a missing chat_messages array means the
+      // internal API changed, which we surface clearly rather than as "no messages".
+      if (!conversationData || typeof conversationData !== 'object' || !Array.isArray(conversationData.chat_messages)) {
+        throw new Error('Unexpected API response — chat_messages is missing (the endpoint may have changed).');
       }
 
-      const humanButtons = getCopyButtons(false);
-      const claudeButtons = getCopyButtons(true);
-
-      if (humanButtons.length === 0 && claudeButtons.length === 0) {
-        throw new Error('No copy buttons found!');
+      const messages = getOrderedMessages(conversationData);
+      if (!messages.length) {
+        const hadContent = conversationData.chat_messages.some(m => Array.isArray(m.content) && m.content.length);
+        throw new Error(hadContent
+          ? 'No exportable content extracted — the message/content shape may have changed.'
+          : 'No messages found in this conversation.');
       }
 
-      // A conversation normally has both message types; a one-sided result
-      // suggests the attribution markers changed and export may mislabel
-      if ((humanButtons.length === 0) !== (claudeButtons.length === 0)) {
-        console.warn(`⚠️ Suspicious: ${humanButtons.length} human vs ${claudeButtons.length} Claude copy buttons — attribution markers may have changed`);
-      }
+      const { markdown, anyIncomplete } = buildMarkdown(messages);
+      const filename = `${getConversationTitle()}.md`;
+      downloadMarkdown(markdown, filename);
 
-      // Phase 1: Human messages
-      statusDiv.textContent = 'Copying human messages...';
-      currentCapture = humanMessages;
-      await triggerCopyButtons(humanButtons);
-      await waitForClipboardOperations(humanMessages, humanButtons.length);
-
-      // Phase 2: Claude responses
-      statusDiv.textContent = 'Copying Claude responses...';
-      currentCapture = capturedResponses;
-      await triggerCopyButtons(claudeButtons);
-      await waitForClipboardOperations(capturedResponses, claudeButtons.length);
-
-      completeExport(timestamps);
+      const notes = [];
+      if (anyIncomplete) notes.push('some responses incomplete');
+      if (warnings.length) notes.push(`${warnings.length} warning${warnings.length === 1 ? '' : 's'} — see console`);
+      const clean = notes.length === 0;
+      statusDiv.textContent = `${clean ? '✅' : '⚠️'} Exported ${messages.length} messages${notes.length ? ` (${notes.join('; ')})` : ''}: ${filename}`;
+      statusDiv.style.background = clean ? '#4CAF50' : '#ff9800';
+      console.log(`🎉 Export complete — ${messages.length} messages → ${filename}`);
 
     } catch (error) {
       statusDiv.textContent = `Error: ${error.message}`;
       statusDiv.style.background = '#f44336';
       console.error('Export failed:', error);
     } finally {
-      setTimeout(cleanup, 3000);
+      setTimeout(cleanup, 4000);
     }
   }
 
-  function completeExport(timestamps) {
-    interceptorActive = false;
-
-    if (humanMessages.length === 0 && capturedResponses.length === 0) {
-      statusDiv.textContent = 'No messages captured!';
-      statusDiv.style.background = '#f44336';
-      return;
-    }
-
-    const markdown = buildMarkdown(timestamps);
-    const filename = `${getConversationTitle()}.md`;
-    downloadMarkdown(markdown, filename);
-
-    statusDiv.textContent = `✅ Downloaded: ${filename}`;
-    statusDiv.style.background = '#4CAF50';
-
-    console.log('🎉 Export complete!');
-  }
-
-  function cleanup() {
-    navigator.clipboard.writeText = originalWriteText;
-    if (document.body.contains(statusDiv)) {
-      document.body.removeChild(statusDiv);
-    }
-  }
-
-  // Initialize
-  updateStatus();
-  setTimeout(startExport, 1000);
+  startExport();
 }
 
 // Run the exporter

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,252 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Claude Chat Exporter — one-click bookmarklet</title>
+<meta name="description" content="Export any Claude.ai conversation to clean, faithful Markdown with one click — artifacts, code, tables, math and attachments included. Runs in your browser, no servers, open source. Obsidian & RAG ready.">
+<style>
+  :root {
+    --accent: #d97757;
+    --accent-strong: #c25f3f;
+    --bg: #faf9f6;
+    --card: #ffffff;
+    --text: #1c1b19;
+    --muted: #6b6a67;
+    --border: rgba(0,0,0,.09);
+    --shadow: 0 1px 2px rgba(0,0,0,.04), 0 8px 24px rgba(0,0,0,.06);
+    color-scheme: light dark;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #131417;
+      --card: #1c1e22;
+      --text: #ececec;
+      --muted: #9a9a9a;
+      --border: rgba(255,255,255,.10);
+      --shadow: 0 1px 2px rgba(0,0,0,.3), 0 8px 24px rgba(0,0,0,.35);
+    }
+  }
+  * { box-sizing: border-box; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    line-height: 1.6; margin: 0; color: var(--text); background: var(--bg);
+    -webkit-font-smoothing: antialiased;
+  }
+  a { color: inherit; }
+  code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: .9em; }
+  .wrap { max-width: 760px; margin-inline: auto; padding: 0 1.25rem 2rem; }
+
+  /* top bar */
+  .topbar { display: flex; align-items: center; justify-content: space-between; gap: 1rem; padding: 1rem 0; }
+  .brand { display: flex; align-items: center; gap: .55rem; font-weight: 700; font-size: 1.02rem; }
+  .brand .mark { width: 26px; height: 26px; border-radius: 7px; background: var(--accent);
+    display: grid; place-items: center; font-size: .95rem; }
+  .star { display: inline-flex; align-items: center; gap: .4rem; text-decoration: none;
+    font-size: .88rem; font-weight: 600; padding: .42rem .8rem; border: 1px solid var(--border);
+    border-radius: 999px; background: var(--card); box-shadow: var(--shadow); transition: .15s; }
+  .star:hover { border-color: var(--accent); transform: translateY(-1px); }
+  .star svg { width: 16px; height: 16px; fill: currentColor; }
+  .star .count { font-variant-numeric: tabular-nums; margin-left: .3rem; color: var(--muted); }
+
+  /* hero */
+  .hero { text-align: center; padding: 2.2rem 0 1rem; }
+  .hero h1 { font-size: 2.15rem; line-height: 1.15; margin: 0 0 .6rem; letter-spacing: -.02em; }
+  .hero .lead { font-size: 1.1rem; color: var(--muted); margin: 0 auto .7rem; max-width: 32rem; }
+  .hero .trust { font-size: .85rem; color: var(--muted); margin: 0 auto 1.5rem; }
+  .hero .trust strong { color: var(--accent); }
+  .drag { display: inline-flex; align-items: center; gap: .5rem; margin: 0 0 .55rem;
+    padding: .95rem 1.7rem; background: var(--accent); color: #fff; text-decoration: none;
+    font-weight: 700; font-size: 1.15rem; border-radius: 12px; box-shadow: 0 6px 20px rgba(217,119,87,.35);
+    cursor: grab; transition: .15s; }
+  .drag:hover { background: var(--accent-strong); transform: translateY(-1px); }
+  .drag[aria-disabled="true"] { opacity: .55; cursor: default; box-shadow: none; }
+  .hint { font-size: .9rem; color: var(--muted); margin: 0; }
+
+  /* capability strip */
+  .caps { display: grid; grid-template-columns: repeat(4, 1fr); gap: .75rem; margin: 2rem 0; }
+  .cap { background: var(--card); border: 1px solid var(--border); border-radius: 12px;
+    padding: .95rem; box-shadow: var(--shadow); }
+  .cap .ic { font-size: 1.3rem; line-height: 1; }
+  .cap b { display: block; margin-top: .4rem; font-size: .92rem; }
+  .cap span { font-size: .82rem; color: var(--muted); }
+
+  h2.sec { font-size: 1.1rem; margin: 2.2rem 0 .8rem; }
+
+  /* steps */
+  ol.steps { list-style: none; counter-reset: s; padding: 0; margin: 0; display: grid; gap: .6rem; }
+  ol.steps li { counter-increment: s; position: relative; padding: .8rem .95rem .8rem 3rem;
+    background: var(--card); border: 1px solid var(--border); border-radius: 12px; box-shadow: var(--shadow); }
+  ol.steps li::before { content: counter(s); position: absolute; left: .8rem; top: 50%;
+    transform: translateY(-50%); width: 1.6rem; height: 1.6rem; border-radius: 50%;
+    background: var(--accent); color: #fff; display: grid; place-items: center; font-weight: 700; font-size: .85rem; }
+
+  .note { background: var(--card); border: 1px solid var(--border); border-radius: 12px;
+    padding: 1rem 1.15rem; font-size: .93rem; box-shadow: var(--shadow); margin: 1.4rem 0; }
+  .note.privacy strong { color: var(--accent); }
+  .update { font-size: .88rem; color: var(--muted); margin: 1.2rem 0; text-align: center; }
+  .update strong { color: var(--text); }
+
+  details { margin: 1.25rem 0; background: var(--card); border: 1px solid var(--border);
+    border-radius: 12px; padding: .5rem 1.05rem; box-shadow: var(--shadow); }
+  summary { cursor: pointer; font-weight: 600; padding: .4rem 0; }
+  button.copy { font: inherit; padding: .45rem .9rem; border-radius: 8px; border: 1px solid var(--border);
+    background: transparent; color: inherit; cursor: pointer; }
+  button.copy:hover { background: rgba(127,127,127,.12); }
+
+  footer { margin-top: 2.5rem; padding-top: 1.25rem; border-top: 1px solid var(--border);
+    display: flex; gap: .8rem 1rem; flex-wrap: wrap; align-items: center; justify-content: space-between;
+    font-size: .9rem; color: var(--muted); }
+  footer .ask { margin: 0; }
+  footer .ask a { color: var(--accent); font-weight: 600; text-decoration: none; }
+  footer .ask a:hover { text-decoration: underline; }
+  footer a.pill { text-decoration: none; padding: .35rem .8rem; border-radius: 999px;
+    border: 1px solid var(--border); color: inherit; }
+  footer a.pill:hover { border-color: var(--accent); }
+
+  @media (max-width: 640px) {
+    .caps { grid-template-columns: repeat(2, 1fr); }
+    .hero h1 { font-size: 1.75rem; }
+  }
+</style>
+</head>
+<body>
+  <div class="wrap">
+    <div class="topbar">
+      <div class="brand"><span class="mark">📥</span> Claude Chat Exporter</div>
+      <a class="star" href="https://github.com/agarwalvishal/claude-chat-exporter" target="_blank" rel="noopener" title="Star this project on GitHub">
+        <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.65 7.65 0 0 1 2-.27c.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
+        Star<span class="count" id="star-count" hidden></span>
+      </a>
+    </div>
+
+    <header class="hero">
+      <h1>Export any Claude chat to perfect Markdown</h1>
+      <p class="lead">One click. A clean, faithful <code>.md</code> file — exactly what Claude wrote.</p>
+      <p class="trust">🔒 <strong>Private by design</strong> · runs in your browser · no servers · no tracking · open source</p>
+      <a id="bm" class="drag" href="#" aria-disabled="true">📥 Claude Export</a>
+      <p class="hint" id="hint">Preparing the latest version…</p>
+    </header>
+
+    <div class="caps">
+      <div class="cap"><div class="ic">🎯</div><b>100% fidelity</b><span>Tables, math &amp; code, byte-perfect</span></div>
+      <div class="cap"><div class="ic">🧩</div><b>Artifacts &amp; widgets</b><span>Captured as clean code blocks</span></div>
+      <div class="cap"><div class="ic">📎</div><b>Attachments</b><span>Images, docs &amp; files included</span></div>
+      <div class="cap"><div class="ic">🗂️</div><b>Obsidian &amp; RAG ready</b><span>Frontmatter + clean structure</span></div>
+    </div>
+
+    <h2 class="sec">Get started in 10 seconds</h2>
+    <ol class="steps">
+      <li><strong>Drag</strong> the “📥 Claude Export” button above onto your browser's bookmarks bar.</li>
+      <li>Open any conversation on <a href="https://claude.ai" target="_blank" rel="noopener">claude.ai</a>.</li>
+      <li><strong>Click the bookmark</strong> — a brief status appears and your <code>.md</code> file downloads automatically.</li>
+    </ol>
+
+    <p class="update"><strong>Always up to date:</strong> the bookmarklet checks for updates and flags when a newer version is available — just re-drag (or re-copy) to grab it.</p>
+
+    <p class="note privacy">🔒 <strong>Private by design — no servers, no tracking.</strong> This is just an open-source script that runs in your browser; your conversation is read from Claude's own site (the one you're already on) over your existing session, processed locally, and never uploaded anywhere. Nothing you export is sent to us or anyone else.</p>
+
+    <details>
+      <summary>Can't drag it? Add the bookmark manually</summary>
+      <p>Create a new bookmark, then paste the copied code as its <em>URL/Address</em>. Open a Claude conversation and click the bookmark.</p>
+      <p><button class="copy" id="copy" disabled>Copy bookmarklet code</button> <span id="copied"></span></p>
+    </details>
+
+    <footer>
+      <p class="ask">Enjoying it? A <a href="https://github.com/agarwalvishal/claude-chat-exporter" target="_blank" rel="noopener">⭐ star on GitHub</a> helps others discover it.</p>
+      <a class="pill" href="https://github.com/agarwalvishal/claude-chat-exporter#readme" target="_blank" rel="noopener">📖 Docs</a>
+    </footer>
+  </div>
+
+<script>
+  // ─────────────────────────────────────────────────────────────────────────
+  // This page assembles the bookmarklet HERE, on the friendly github.io origin,
+  // and only ever bakes the export script into a draggable link. The dragged
+  // bookmarklet runs *inline* on claude.ai (a browser-level CSP exemption) — it
+  // never fetches-and-evals code there, so Claude's strict CSP doesn't affect it.
+  //
+  // claude-chat-exporter.js is embedded VERBATIM and is never modified. The only
+  // added behaviour is a self-contained "update available" shim (below), which
+  // lives entirely in this packaging layer — not in the core script.
+  // ─────────────────────────────────────────────────────────────────────────
+  var RAW  = "https://raw.githubusercontent.com/agarwalvishal/claude-chat-exporter/main/claude-chat-exporter.js";
+  var PAGE = "https://agarwalvishal.github.io/claude-chat-exporter/";
+
+  // Cheap change-detection hash (djb2). Not security — just "did the file change?"
+  function hash(s) { var h = 5381, i = s.length; while (i) h = (h * 33) ^ s.charCodeAt(--i); return (h >>> 0).toString(16); }
+
+  // Self-contained update-notice shim, baked into the bookmarklet. "{{HASH}}" is
+  // replaced with the hash of the core script this bookmarklet was built from.
+  // At run time it re-fetches the latest core, hashes it, and if they differ shows
+  // a one-click "update available" notice. It does not touch the core script.
+  var SHIM = [
+    '(function(){',
+      'try{',
+        'var B="{{HASH}}",U=' + JSON.stringify(RAW) + ',P=' + JSON.stringify(PAGE) + ';',
+        'function h(s){var x=5381,i=s.length;while(i)x=(x*33)^s.charCodeAt(--i);return(x>>>0).toString(16);}',
+        'fetch(U).then(function(r){return r.text();}).then(function(t){',
+          'if(h(t)!==B){',
+            'var d=document.createElement("div");',
+            'd.textContent="\\u26A0\\uFE0F Claude Chat Exporter: update available \\u2014 click to re-grab";',
+            'd.style.cssText="position:fixed;top:52px;right:10px;z-index:10001;background:#d97757;color:#fff;padding:8px 12px;border-radius:6px;font:12px/1.4 monospace;cursor:pointer;box-shadow:0 2px 10px rgba(0,0,0,.3);max-width:300px";',
+            'd.onclick=function(){window.open(P,"_blank");};',
+            'document.body.appendChild(d);',
+            'setTimeout(function(){d.remove();},15000);',
+          '}',
+        // Quiet by default — a failed update check is not the user's problem.
+        // console.debug is hidden unless the console level is "Verbose", so a
+        // maintainer can still spot a CSP block or outage that would otherwise
+        // disable update notices for everyone with no signal at all.
+        '}).catch(function(e){try{console.debug("[claude-chat-exporter] update check failed:",e);}catch(_){}});',
+      '}catch(e){}',
+    '})();'
+  ].join('');
+
+  var bm = document.getElementById("bm");
+  var hint = document.getElementById("hint");
+  var copyBtn = document.getElementById("copy");
+  var href = null;
+
+  // Clicking (instead of dragging) would run the exporter on THIS page and do nothing useful.
+  bm.addEventListener("click", function (e) {
+    e.preventDefault();
+    hint.textContent = "☝️ Drag it to your bookmarks bar — clicking here does nothing.";
+  });
+
+  fetch(RAW)
+    .then(function (r) { if (!r.ok) throw new Error("HTTP " + r.status); return r.text(); })
+    .then(function (core) {
+      var shim = SHIM.replace("{{HASH}}", hash(core));
+      var full = "(function(){" + shim + "\n" + core + "\n})();";
+      href = "javascript:" + encodeURIComponent(full);
+      bm.href = href;
+      bm.removeAttribute("aria-disabled");
+      hint.textContent = "↑ Drag this button to your bookmarks bar (don't just click it here).";
+      copyBtn.disabled = false;
+    })
+    .catch(function (e) {
+      hint.textContent = "Couldn't load the latest script (" + e.message + "). Try refreshing.";
+    });
+
+  copyBtn.addEventListener("click", function () {
+    if (!href) return;
+    navigator.clipboard.writeText(href).then(function () {
+      document.getElementById("copied").textContent = "Copied ✓";
+    });
+  });
+
+  // Live star count — enhancement only; the chip links to the repo regardless.
+  fetch("https://api.github.com/repos/agarwalvishal/claude-chat-exporter")
+    .then(function (r) { return r.ok ? r.json() : null; })
+    .then(function (d) {
+      if (d && typeof d.stargazers_count === "number") {
+        var n = d.stargazers_count;
+        var el = document.getElementById("star-count");
+        el.textContent = n >= 1000 ? (n / 1000).toFixed(1).replace(/\.0$/, "") + "k" : String(n);
+        el.hidden = false;
+      }
+    })
+    .catch(function () {});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## What this changes

The exporter no longer drives the page. Instead of clicking Claude's copy
buttons and capturing the clipboard, it reads the conversation from the same
internal endpoint claude.ai itself calls — one same-origin fetch, authenticated
by your existing session.

## Why

The copy-button approach was faithful (Claude's copy button hands over real
markdown), but it had limits that couldn't be patched:

1. **It only saw what was rendered.** claude.ai virtualizes the message list,
   so a single DOM snapshot never contains a long conversation. Long chats
   exported partially — the main complaint this fixes.
2. **It was coupled to CSS selectors.** Nearly every commit in this repo's
   recent history is a "fix for Claude's UI changes" commit. Selectors are not
   a contract; the API response shape is a far more stable one.
3. **It could only reach things with a copy button.** Artifacts, attachments
   and widgets have no copy button, so they were unreachable by construction.

The script is now **fully DOM-free** — no selectors at all. The title comes
from the API response, the org ID from a cookie, the conversation ID from the
URL.

## What's new

- **Complete exports.** Every message on the current branch, regardless of what
  is rendered on screen.
- **Reliable turn alignment.** Output is built by walking the message tree from
  `current_leaf_message_uuid` up the parent chain, rather than pairing captured
  human and Claude messages by index. Index pairing assumed strict alternation
  starting on a human turn, so a regenerated branch could attach answers to the
  wrong question; branch-walking removes that class of bug and exports exactly
  the branch you're looking at.
- **Artifacts**, reconstructed to their final version (folding `create` /
  `update` diffs / `rewrite`) and rendered once, at their last edit.
- **Created files** and **`visualize` widgets** as titled fenced code blocks.
- **Attachments** — images embedded, documents linked with page counts, blobs
  named, and text extractions (.md/.docx/…) inlined as blockquotes.
- **Obsidian- and RAG-ready output** — YAML frontmatter (`title`, `source`,
  `model`, `exported`) and one H1 per turn, so Claude's own `##`/`###` content
  nests correctly beneath it and chunking stays sane.
- **Per-message timestamps** for both human and Claude turns.
- **Incomplete-message notes** — truncated and interrupted responses are
  flagged inline rather than silently ending.

## Deliberately out of scope

- **Web search results.** Their URLs are ephemeral — the API marks them
`is_expired` — so exporting them would bake dead links into a document meant to
stay useful offline. Claude's answer text already carries the substance and its
citations, which makes the raw result list redundant bulk.

- **Thinking blocks.** Exploratory reasoning contains discarded hypotheses and
self-corrections, and is often longer than the answer. Indexing it puts rejected
reasoning into RAG retrieval with the same confidence as the conclusion, and it
inflates the document outline.
  - RAG: thinking blocks are process, not conclusions — discarded hypotheses, self-corrections, abandoned branches. A retriever indexing them surfaces reasoning the model itself rejected, with the same confidence as the answer: plausible, retrievable, wrong. They're also often longer than the answer, so they'd dominate chunk budgets.
  - Obsidian: they'd nest under each # Claude — <timestamp> H1 with their own structure, inflating notes and polluting the outline the H1 scheme exists to keep clean.

- **Other tool calls** (bash, file view/edit, display widgets) and the raw binary
bytes of attachments — though text extractions are inlined, so exports stay
self-contained.

## Compatibility

The output format changed: turn headers are now H1, YAML frontmatter is
emitted, and the old standalone title heading and `---` rules are gone. If you
have tooling that parses previous exports, it will need updating.
