### PR TITLE
fix: revalidate the update check instead of trusting a cached copy

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -184,12 +184,16 @@
       'try{',
         'var B="{{HASH}}",U=' + JSON.stringify(RAW) + ',P=' + JSON.stringify(PAGE) + ';',
         'function h(s){var x=5381,i=s.length;while(i)x=(x*33)^s.charCodeAt(--i);return(x>>>0).toString(16);}',
-        'fetch(U).then(function(r){return r.text();}).then(function(t){',
+        // cache:"no-cache" revalidates instead of trusting the browser copy. The raw
+        // endpoint sends max-age=300, and this fetch runs on every export — so without
+        // it the check compares against content up to 5 minutes stale, and the cache it
+        // populates is the same one the install page reads when re-grabbing.
+        'fetch(U,{cache:"no-cache"}).then(function(r){return r.text();}).then(function(t){',
           'if(h(t)!==B){',
             'var d=document.createElement("div");',
             'd.textContent="\\u26A0\\uFE0F Claude Chat Exporter: update available \\u2014 click to re-grab";',
             'd.style.cssText="position:fixed;top:52px;right:10px;z-index:10001;background:#d97757;color:#fff;padding:8px 12px;border-radius:6px;font:12px/1.4 monospace;cursor:pointer;box-shadow:0 2px 10px rgba(0,0,0,.3);max-width:300px";',
-            'd.onclick=function(){window.open(P,"_blank");};',
+            'd.onclick=function(){window.open(P,"_blank");d.remove();};',
             'document.body.appendChild(d);',
             'setTimeout(function(){d.remove();},15000);',
           '}',
@@ -213,7 +217,12 @@
     hint.textContent = "☝️ Drag it to your bookmarks bar — clicking here does nothing.";
   });
 
-  fetch(RAW)
+  // cache:"no-cache" matters most here: this fetch decides which script gets baked into
+  // the bookmarklet. A cached copy would embed a stale exporter *and* its matching hash,
+  // so the result stays self-consistent and never warns — the user silently installs old
+  // code. The shim's own fetch refreshes that cache on every export, so a user arriving
+  // here from the update notice is exactly the one most likely to be served a stale copy.
+  fetch(RAW, { cache: "no-cache" })
     .then(function (r) { if (!r.ok) throw new Error("HTTP " + r.status); return r.text(); })
     .then(function (core) {
       var shim = SHIM.replace("{{HASH}}", hash(core));


### PR DESCRIPTION
## The problem

`raw.githubusercontent.com` sends `cache-control: max-age=300`, and both fetches in
`docs/index.html` used the browser's HTTP cache by default. Together they formed a loop
that defeated the update flow they exist to serve:

1. The shim fetches the script on **every export** — refreshing the cache
2. An update notice fires; the user clicks through to the install page
3. The page's own `fetch(RAW)` is served that **just-refreshed cached copy**
4. It bakes the *old* script — plus a hash *of the old script* — into the newly installed
   bookmarklet. Self-consistent, so it never warns.
5. The user has silently reinstalled the old exporter

Steps 2–3 almost always land inside the five-minute window step 1 just refreshed, so the
update path was *likely* to hit this rather than unlikely.

Observed in practice: after merging #32, re-grabbing the bookmarklet produced one still
running the previous copy-button script, with no indication anything was wrong.

## The fix

`{cache: "no-cache"}` on both fetches. It revalidates with `If-None-Match` and takes a
cheap **304** when nothing changed — accurate every time, without re-downloading the
script on every export. (`no-store` would force that full download for a check that
rarely matters.)

The install-page fetch is the one that matters most: it decides which script gets embedded.
The shim's fetch is fixed too, both for consistency and because it makes the mechanism
verifiable immediately after a merge rather than five minutes later.

## Also included

The update notice now dismisses when clicked. It previously opened the install page but
left the notice on screen until its 15-second timer, which read as unresponsive. This
hides no signal — the notice is recomputed on every run, so if a re-grab doesn't take
effect, it simply appears again.

## Scope

`docs/index.html` only. `claude-chat-exporter.js` is untouched, so the script hash is
unchanged and no existing bookmarklet is affected.

Existing installs keep their original shim and will still see up-to-5-minute staleness
until re-grabbed — unavoidable, since the shim is baked in at install time. Nothing
breaks for them; the notice just arrives late.
