### PR TITLE
fix: stop reporting a stopped response as a degraded export

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,15 @@ The whole flow lives in `setupClaudeExporter()` (one closure, invoked at the bot
    - **Ordering** follows the *current branch*: walk from `data.current_leaf_message_uuid` up the `parent_message_uuid` chain and reverse (so a regenerated response exports the path actually on screen). Falls back to sorting `chat_messages` by `index`.
    - **Content**: each message's `content` is an array of typed blocks (`text`, `thinking`, `tool_use`, `tool_result`). Walk them **in order** — emit `text` blocks and `tool_use` blocks (via `renderToolUse`), skip `thinking`/`tool_result` — so text and special elements stay interleaved. Messages that end up empty are dropped (the API also returns hidden/system messages the UI never shows). `renderToolUse` renders only the three content-bearing tools (`artifacts`→`content`, `create_file`→`file_text`, `visualize:show_widget`→`widget_code`) as titled fenced code blocks with an API-derived kind label (`Artifact:` / `File:` / `Widget:`, no emoji); **every other tool** (web search, bash, file view/edit, display widgets, unknown) is skipped (their names are logged once at `console.debug` — hidden from users, but a maintainer can enable "Verbose" to spot a new content tool to add). Artifacts are special — `collectArtifacts` folds each `id` through `create` / `update` (an `old_str`→`new_str` diff) / `rewrite` into its final content, and it's rendered **once, at its last edit** (matched by `version_uuid`).
 
-3. **`buildMarkdown(messages)`** — emits YAML frontmatter (`title`, `source`, `model`, `exported`) then one `# Human — <timestamp>` / `# Claude — <timestamp>` header per turn (H1 so Claude's own `##`/`###` content nests beneath it — keeps the outline correct for RAG chunking and Obsidian). No separate title heading or `---` rules. Appends an inline word-based notice to **incomplete** messages via `incompleteNote()`, flagging the two signals verified in the API — `truncated` → **Truncated**, `stop_reason: 'user_canceled'` → **Interrupted** (everything else, incl. a rare length-limited response, is left unannotated rather than guessing an unverified `stop_reason` value). The exported document is **emoji-free**; emojis appear only in the transient status box / console. Tuned for RAG/Obsidian ingestion.
+3. **`buildMarkdown(messages)`** — emits YAML frontmatter (`title`, `source`, `model`, `exported`) then one `# Human — <timestamp>` / `# Claude — <timestamp>` header per turn (H1 so Claude's own `##`/`###` content nests beneath it — keeps the outline correct for RAG chunking and Obsidian). No separate title heading or `---` rules. Appends an inline word-based notice to **incomplete** messages via `incompleteNote()` — `truncated` → **Truncated**, `stop_reason: 'user_canceled'` → **Interrupted** (everything else, including a length-limited response, is left unannotated rather than guessing at an unobserved `stop_reason` value). Returns `{ markdown, interrupted, truncated }` — **counts, not a boolean**, because the two mean different things to the reader and only one of them is a problem:
+
+| Signal | Meaning | Status box |
+|---|---|---|
+| `stop_reason: 'user_canceled'` | The user stopped the response; there is no further content | ✅ green — the export is complete and faithful |
+| `truncated` | The API set a flag whose trigger we have never observed | ⚠️ orange, on precaution |
+| `warnings[]` | Something didn't reconstruct cleanly (see the four `warn()` sites) | ⚠️ orange |
+
+`startExport` therefore computes `clean = warnings.length === 0 && truncated === 0`. **Do not fold `interrupted` back into that** — treating a response the user deliberately stopped as a warning tells people a perfectly good export went wrong, which is the bug this replaced. Wording stays observational (*"N messages flagged truncated"*) since the meaning is unconfirmed. The exported document is **emoji-free**; emojis appear only in the transient status box / console. Tuned for RAG/Obsidian ingestion.
 
 4. **Title + download** — `getConversationTitle()` uses `conversationData.name` (falls back to `'claude_conversation'`; fully DOM-free), then `downloadMarkdown()` writes the `.md` file.
 
@@ -42,8 +50,17 @@ The whole flow lives in `setupClaudeExporter()` (one closure, invoked at the bot
     index,                       // fallback ordering
     sender: 'human' | 'assistant',
     created_at,                  // ISO timestamp
-    truncated,                   // bool; rare source-data content truncation → inline "Truncated" note
-    stop_reason,                 // assistant only: 'end_turn'/'stop_sequence' = complete, 'user_canceled' = interrupted (flagged); other values left unannotated
+    truncated,                   // bool. VERIFIED to exist (probed uncoerced 2026-07-27; the
+                                 // key came back present as `false` on every message, and an
+                                 // absent field would have been dropped from the JSON). Never
+                                 // observed `true`, so its trigger and meaning are UNKNOWN —
+                                 // the name suggests content truncation but nothing confirms
+                                 // it. Flagged inline + ⚠️ on precaution, worded as an
+                                 // observation, never as a claim that content is missing.
+    stop_reason,                 // assistant only. 'user_canceled' = interrupted — VERIFIED
+                                 // against a real stopped response. 'end_turn'/'stop_sequence'
+                                 // as the "complete" values are ASSUMED, not observed. Other
+                                 // values left unannotated rather than guessed at.
     content: [{ type: 'text' | 'thinking' | 'tool_use' | 'tool_result', text?, ... }],
     files:       [ /* uploaded files, see below */ ],
     attachments: [ /* text-extracted docs, see below */ ]
@@ -79,4 +96,4 @@ This is an **internal, undocumented Anthropic endpoint** — no public docs, no 
 
 Exports every message's answer text plus its **content-bearing special elements** on the current branch: artifacts (reconstructed to their final version, rendered once), created files, and `visualize` widgets (charts/diagrams) as fenced code blocks. **Every other tool call is skipped** — web search, bash, file view/edit, and display widgets (maps, recipes, image/place search); their result URLs are ephemeral (the API flags them `is_expired`). Claude's internal `thinking` blocks are also skipped — **excluded by design, not deferred**: exploratory reasoning and discarded hypotheses pollute RAG retrieval and the document outline, and web search results would bake `is_expired` dead links into a document meant to stay useful offline. Treat requests to add either as out of scope (see issues #11 and #19). (`visualize:show_widget` and `create_file` have no revision model, so a "refined" widget/file is a new block and renders each time; only `artifacts` reconstruct.)
 
-Attachments: `describeAttachments()` renders each attachment above the message text, by what the API offers — `m.files` images → embed (`preview_url`); `m.files` documents → link (`document_asset.url`, `page_count`); `m.files` blobs (audio, no URL) → named; `m.attachments` text extractions (.md/.docx/…) → their `extracted_content` inlined as a **blockquote** (so the attachment's own headings stay quoted, out of the document outline). Each carries a word label — **`Attachment: <name> · <meta>`** (no emoji), consistent with `Artifact:`/`File:`/`Widget:`. Runs for **every** message, so an attachment-only turn is never dropped. Text content is inlined (self-contained/RAG-complete); the raw *binary* bytes are not — a portable ZIP bundling the originals is the deferred/premium step.
+Attachments: `describeAttachments()` renders each attachment above the message text, by what the API offers — `m.files` images → embed (`preview_url`); `m.files` documents → link (`document_asset.url`, `page_count`); `m.files` blobs (audio, no URL) → named; `m.attachments` text extractions (.md/.docx/…) → their `extracted_content` inlined as a **blockquote** (so the attachment's own headings stay quoted, out of the document outline). Each carries a word label — **`Attachment: <name> · <meta>`** (no emoji), consistent with `Artifact:`/`File:`/`Widget:`. Runs for **every** message, so an attachment-only turn is never dropped. Text content is inlined (self-contained/RAG-complete); the raw *binary* bytes are not — a portable ZIP bundling the originals is deferred work.

--- a/README.md
+++ b/README.md
@@ -184,8 +184,10 @@ The script shows a small status box while it runs:
 
 - `Fetching conversation…` - Reading the conversation from Claude's API
 - `✅ Exported N messages: filename.md` - Success!
-- `⚠️ Exported N messages (some responses incomplete): filename.md` - Success, but one or more messages were interrupted or truncated in the source data (each is flagged inline)
-- `Error: …` - Something went wrong (details in the console)
+- `✅ Exported N messages (1 interrupted response): filename.md` - Success. A response was stopped before Claude finished, so there was never any more of it to export — **your file is complete**. The message is flagged inline so the short answer isn't mistaken for a bug
+- `⚠️ Exported N messages (1 message flagged truncated): filename.md` - Claude's API marked a message `truncated`. It's flagged inline; compare that message against the page if you want to be sure nothing is missing
+- `⚠️ Exported N messages (1 warning — see console): filename.md` - The file downloaded, but something didn't reconstruct cleanly — usually an artifact whose edit couldn't be applied to its original text, occasionally an unexpected value from the API. Each warning is logged to the console as it happens
+- `Error: …` - The export didn't happen, and the box itself says why — e.g. `Open a specific Claude conversation first…` or `your session may have expired; reload and sign in`. The console logs the full error too
 
 ### Common Issues
 

--- a/claude-chat-exporter.js
+++ b/claude-chat-exporter.js
@@ -399,7 +399,12 @@ function setupClaudeExporter() {
     frontMatter.push(`exported: ${new Date().toISOString().slice(0, 10)}`, '---', '');
 
     let markdown = frontMatter.join('\n') + '\n';
-    let anyIncomplete = false;
+    // Counted separately because they mean different things to the reader: an
+    // interrupted response means nothing is missing (the user stopped it, so there
+    // is no more content), whereas `truncated` is a flag whose meaning we can't
+    // confirm. Only the latter degrades the status box — see startExport.
+    let interrupted = 0;
+    let truncated = 0;
 
     for (const message of messages) {
       const who = message.sender === 'human' ? 'Human' : 'Claude';
@@ -409,14 +414,15 @@ function setupClaudeExporter() {
       let body = message.text;
       const note = incompleteNote(message);
       if (note) {
-        anyIncomplete = true;
+        // Mirrors incompleteNote's precedence: `truncated` is checked first and wins.
+        if (message.truncated) truncated++; else interrupted++;
         body += `\n\n${note}`;
       }
 
       markdown += `${header}\n\n${body}\n\n`;
     }
 
-    return { markdown, anyIncomplete };
+    return { markdown, interrupted, truncated };
   }
 
   // Status indicator
@@ -454,14 +460,20 @@ function setupClaudeExporter() {
           : 'No messages found in this conversation.');
       }
 
-      const { markdown, anyIncomplete } = buildMarkdown(messages);
+      const { markdown, interrupted, truncated } = buildMarkdown(messages);
       const filename = `${getConversationTitle()}.md`;
       downloadMarkdown(markdown, filename);
 
+      // Two categories, deliberately separated. An interrupted response is a fact
+      // about the *conversation* — the export is complete and faithful — so it must
+      // not colour the box like a failure. Only `truncated` (whose meaning is
+      // unconfirmed, so treated as a warning on precaution) and real processing
+      // `warnings` degrade the status.
       const notes = [];
-      if (anyIncomplete) notes.push('some responses incomplete');
+      if (interrupted) notes.push(`${interrupted} interrupted response${interrupted === 1 ? '' : 's'}`);
+      if (truncated) notes.push(`${truncated} message${truncated === 1 ? '' : 's'} flagged truncated`);
       if (warnings.length) notes.push(`${warnings.length} warning${warnings.length === 1 ? '' : 's'} — see console`);
-      const clean = notes.length === 0;
+      const clean = warnings.length === 0 && truncated === 0;
       statusDiv.textContent = `${clean ? '✅' : '⚠️'} Exported ${messages.length} messages${notes.length ? ` (${notes.join('; ')})` : ''}: ${filename}`;
       statusDiv.style.background = clean ? '#4CAF50' : '#ff9800';
       console.log(`🎉 Export complete — ${messages.length} messages → ${filename}`);


### PR DESCRIPTION
## The problem

Exporting a conversation that contained a response the user had stopped produced:

```
⚠️ Exported 8 messages (some responses incomplete): file.md
```

…in the orange warning colour. Both halves of that were misleading:

- **The wording has no subject**, so it reads as *"the export is incomplete."* Nothing was
  missing. The response simply ended where the user stopped it, and the file contained
  everything that existed.
- **The colour said something went wrong.** `anyIncomplete` shared a bucket with genuine
  `warnings`, so a deliberate user action got the same treatment as an artifact edit that
  couldn't be applied.

Stopping a response is a normal thing to do, so this would have been a recurring source of
doubt about whether exports were trustworthy.

## The fix

Separate facts about the *conversation* from problems with the *export*:

| Signal | Meaning | Status |
|---|---|---|
| `stop_reason: 'user_canceled'` | The user stopped it; no further content exists | ✅ green |
| `truncated` | An API flag whose trigger has never been observed | ⚠️ orange, on precaution |
| `warnings[]` | Something didn't reconstruct cleanly | ⚠️ orange |

```js
clean = warnings.length === 0 && truncated === 0
```

`buildMarkdown` now returns counts instead of an `anyIncomplete` boolean, counting `truncated`
first to mirror `incompleteNote`'s precedence.

Resulting states:

```
✅ Exported 12 messages: file.md
✅ Exported 8 messages (1 interrupted response): file.md
⚠️ Exported 8 messages (1 message flagged truncated): file.md
⚠️ Exported 8 messages (1 warning — see console): file.md
```

## On `truncated`

Kept at warning severity — if it does mean content loss, silent green would be worse — but
worded as an **observation** (*"N messages flagged truncated"*) rather than a diagnosis,
because we cannot support a stronger claim:

- The field **exists**: probed uncoerced against the live API, and the key came back present
  as `false` on every message (an absent field would have been dropped from the JSON).
- It has **never been observed `true`**, so its trigger and meaning are unknown.

`CLAUDE.md` previously called it *"rare source-data content truncation"* — asserting both a
frequency and a meaning, neither of which was ever established. That now records what was
actually verified, and likewise distinguishes the verified `stop_reason` value
(`'user_canceled'`, confirmed against a real stopped response) from the assumed ones
(`'end_turn'` / `'stop_sequence'`).

## Documentation

- **`README.md`** — status-indicator list rewritten for the distinct states. It also claimed
  error details were "in the console" when the status box itself carries the reason
  (`Open a specific Claude conversation first…`, `your session may have expired…`); the
  console only adds the error object.
- **`CLAUDE.md`** — documents the counts, the severity split, and an explicit note not to fold
  `interrupted` back into `clean`, since doing so reintroduces exactly this bug.
